### PR TITLE
latest: use ansible >= 4.0.0 for osism-ansible

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -1,5 +1,5 @@
 ---
-ansible_version: '>=3.0.0,<4.0.0'
+ansible_version: '>=4.0.0,<5.0.0'
 ansible_base_version: '>=2.10.0,<2.11.0'
 manager_version: latest
 repository_version: latest


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>