### PR TITLE
Revert "latest: use ansible >= 4.0.0 for osism-ansible"

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -1,5 +1,5 @@
 ---
-ansible_version: '>=4.0.0,<5.0.0'
+ansible_version: '>=3.0.0,<4.0.0'
 ansible_base_version: '>=2.10.0,<2.11.0'
 manager_version: latest
 repository_version: latest


### PR DESCRIPTION
This reverts commit 3c4b64a94d9f979a726c443a60e61e4ee723a92f.

Signed-off-by: Christian Berendt <berendt@osism.tech>