### PR TITLE
Remove keycloak_for_traefik

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -35,7 +35,6 @@ alerta: alerta/alerta-web
 cgit: clearlinux/cgit
 dnsdist: osism/dnsdist
 keycloak: keycloak/keycloak
-keycloak_for_traefik: osism/keycloak
 netbox: osism/netbox
 
 # zuul


### PR DESCRIPTION
Parameter is left and is no longer needed.

Signed-off-by: Christian Berendt <berendt@osism.tech>