### PR TITLE
latest: use keycloak 17.0.0-legacy

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -17,7 +17,7 @@ docker_images:
   cgit: latest
   dnsdist: 1.6.1
   homer: 21.09.2
-  keycloak: 17.0.0
+  keycloak: 17.0.0-legacy
   mariadb: 10.6.7
   netbox: v3.1.9-ldap
   nexus: 3.38.0

--- a/src/update-base-versions.py
+++ b/src/update-base-versions.py
@@ -253,7 +253,7 @@ def set_base_versions():
     if loaded['docker_images']['ara_server'] is not None:
         loaded['docker_images']['ara_server'] = get_ara_server_latest_tag()
     if loaded['docker_images']['keycloak'] is not None:
-        loaded['docker_images']['keycloak'] = get_keycloak_latest_tag()
+        loaded['docker_images']['keycloak'] = "%s-legacy" % get_keycloak_latest_tag()
     if loaded['docker_images']['mariadb'] is not None:
         loaded['docker_images']['mariadb'] = get_mariadb_latest_tag()
     if loaded['docker_images']['netbox'] is not None:


### PR DESCRIPTION
Necessary to be able to work with the DB_ parameters

Signed-off-by: Christian Berendt <berendt@osism.tech>