### PR TITLE
Add auto-renovate for the requirements.txt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "github>osism/renovate-config"
   ],
+  "pip_requierements": {
+    "fileMatch": ["requirements.txt"]
+  },
   "regexManagers":[
     {
       "fileMatch":[


### PR DESCRIPTION
- Add the auto-renovate for the requirements.txt to fix Sphinx-version issues.
- This is partly osism/issue#155

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
