### PR TITLE
Fix the Renovate-Docker-Version-Bug with the v what not should be shown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -127,7 +127,9 @@
       ],
       "matchStrings":[
         "# renovate: datasource=(?<datasource>github-releases) depName=(?<depName>.*?)\n.*?docker: '5:(?<currentValue>.*?)'"
-      ]
+      ],
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
     },
     {
       "fileMatch":[

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -130,7 +130,6 @@
       ],
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
-    },
     {
       "fileMatch":[
         "^latest\\/base.yml$"


### PR DESCRIPTION
- Fix the in the title called bug with adding a regexp to the renovate.json
- This closes issue#352

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
