### PR TITLE
latest/xena: use versions instead of stable

### DIFF
--- a/latest/openstack-xena.yml
+++ b/latest/openstack-xena.yml
@@ -39,28 +39,28 @@ infrastructure_projects:
   zookeeper:
 
 openstack_projects:
-  aodh:
-  barbican:
-  bifrost:
-  ceilometer:
-  cinder:
-  cloudkitty:
-  designate:
-  glance:
+  aodh: 13.0.0
+  barbican: 13.0.0
+  bifrost: 12.0.0
+  ceilometer: 17.0.1
+  cinder: 19.1.0
+  cloudkitty: 15.0.0
+  designate: 13.0.1
+  glance: 23.0.0
   gnocchi: 4.4.1
-  heat:
-  horizon:
-  ironic:
-  keystone:
-  kuryr:
-  magnum:
-  manila:
-  mistral:
-  neutron-vpnaas-agent:
-  neutron:
-  nova:
-  octavia:
-  placement:
-  senlin:
-  swift:
-  trove:
+  heat: 17.0.1
+  horizon: 20.1.2
+  ironic: 18.2.1
+  keystone: 20.0.0
+  kuryr: 2.4.0
+  magnum: 13.0.0
+  manila: 13.0.3
+  mistral: 13.0.0
+  neutron-vpnaas-agent: 19.0.0
+  neutron: 19.3.0
+  nova: 24.1.1
+  octavia: 9.0.1
+  placement: 6.0.0
+  senlin: 12.0.0
+  swift: 2.28.0
+  trove: 16.0.0


### PR DESCRIPTION
Reproducibility makes it necessary to use static versions
instead of the stable branch. Also in latest in preparations
for a release.

Signed-off-by: Christian Berendt <berendt@osism.tech>