### PR TITLE
3.2.0: update defaults for base

### DIFF
--- a/3.2.0/base.yml
+++ b/3.2.0/base.yml
@@ -3,7 +3,7 @@ ansible_version: 5.5.0
 
 manager_version: 3.2.0
 
-defaults_version: 1558ef400a1acc951260d2094c64a9f630817beb
+defaults_version: ce9dd9a48508d87f48dce22978c94a1114627094
 generics_version: d5738692218e0e19ae1d81d53be6a65f3f31c165
 operations_version: 1cc3699edeb00ac2e0b7c3eaf0de800b8e02fb0f
 playbooks_version: b7137de343b8ceeb0e91793db7ada79537d778ea


### PR DESCRIPTION
Because of the wrong ironic_inspector_tag.

Signed-off-by: Christian Berendt <berendt@osism.tech>