### PR TITLE
latest: fix ansible version for ceph-pacific

### DIFF
--- a/latest/ceph-pacific.yml
+++ b/latest/ceph-pacific.yml
@@ -1,5 +1,5 @@
 ---
-ansible_version: ">=2.9,<2.10"
+ansible_version: ">=2.10,<2.11"
 
 ceph_ansible_version: stable-6.0
 ceph_container_version: stable-6.0


### PR DESCRIPTION
Should be Ansible 2.10.x and not Ansible 2.9.x

Closes osism/issues#293

Signed-off-by: Christian Berendt <berendt@osism.tech>