### PR TITLE
netbox: use tag without -ldap

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -36,7 +36,7 @@ docker_images:
   # renovate: datasource=docker depName=memcached
   memcached: '1.6.17-alpine'
   # renovate: datasource=docker depName=quay.io/osism/netbox
-  netbox: 'v3.2.5-ldap'
+  netbox: 'v3.2.5'
   # renovate: datasource=docker depName=quay.io/osism/nexus
   nexus: '3.43.0'
   # renovate: datasource=docker depName=nginx


### PR DESCRIPTION
Upstream no longer builds the tag since version 3.2.5.

Part of osism/issues#376

Signed-off-by: Christian Berendt <berendt@osism.tech>