### PR TITLE
latest: remove community.zabbix ansible collection

### DIFF
--- a/doc/source/notes/5.0.0.rst
+++ b/doc/source/notes/5.0.0.rst
@@ -217,6 +217,8 @@ Removals
 * The ``ospurge`` wrapper script has been removed from the ``osism.services.openstackclient`` role.
   The ospurge project is no longer compatible with the current OpenStack SDK. The command
   ``openstack project purge`` can be used as an alternative.
+* Support for Zabbix was already removed in OSISM 3.0.0. The Ansible collection
+  ``community.zabbix`` was still present as a leftover.
 
 Housekeeping
 ============

--- a/latest/base.yml
+++ b/latest/base.yml
@@ -92,7 +92,6 @@ ansible_collections:
   ansible.utils: '2.8.0'
   community.general: '5.8.3'
   community.network: '4.0.2'
-  community.zabbix: '1.9.0'
   debops.debops: '3.0.3'
   kubernetes.core: '2.3.2'
   netbox.netbox: '3.10.0'


### PR DESCRIPTION
Support for Zabbix was already removed in OSISM 3.0.0. The Ansible collection community.zabbix was still present as a leftover.

Signed-off-by: Christian Berendt <berendt@osism.tech>