### PR TITLE
4.2.0: use osism 0.7.0

### DIFF
--- a/4.2.0/base.yml
+++ b/4.2.0/base.yml
@@ -27,7 +27,7 @@ docker_images:
   nginx: '1.23.2-alpine'
   docker_openpolicyagent: '0.8'
   openstack_health_monitor: 'v3.0.0'
-  osism: '0.5.0'
+  osism: '0.7.0'
   patchman: '2.0.3'
   phpmyadmin: '5.2.0'
   postgres: '14.5-alpine'


### PR DESCRIPTION
Required to use everywhere the same version.

Signed-off-by: Christian Berendt <berendt@osism.tech>