### PR TITLE
notes: do not remove mistral

### DIFF
--- a/doc/source/notes/5.0.0.rst
+++ b/doc/source/notes/5.0.0.rst
@@ -287,7 +287,6 @@ Deprecations
   as of now and will be removed in the future (exact removal date is not yet known)
 * Magnum (currently available as Technical Preview) will be removed in favor of Gardener and
   Cluster API
-* Mistral (currently available as Technical Preview) will be removed
 * Swift (currently available as Technical Preview) will be removed in favor of Ceph RGW
 * Trove (currently available as Technical Preview) will be removed in favor of Kubernetes
   database operators


### PR DESCRIPTION
https://review.opendev.org/c/openstack/governance/+/866562

OVH takes over. Gates are green again.

Signed-off-by: Christian Berendt <berendt@osism.tech>