### PR TITLE
notes: do not deprecate magnum

### DIFF
--- a/doc/source/notes/5.0.0.rst
+++ b/doc/source/notes/5.0.0.rst
@@ -291,8 +291,6 @@ Deprecations
   will be used.
 * Heat is deprecated in favor of more generic Infrastructure as Code tools like Terraform
   as of now and will be removed in the future (exact removal date is not yet known)
-* Magnum (currently available as Technical Preview) will be removed in favor of Gardener and
-  Cluster API
 * Swift (currently available as Technical Preview) will be removed in favor of Ceph RGW
 * Trove (currently available as Technical Preview) will be removed in favor of Kubernetes
   database operators


### PR DESCRIPTION
Because of https://github.com/vexxhost/magnum-cluster-api the Magnum service makes now sense in the contect of the SCS project.

Signed-off-by: Christian Berendt <berendt@osism.tech>