### PR TITLE
zed: remove ovsdpdk for the moment

### DIFF
--- a/latest/openstack-zed.yml
+++ b/latest/openstack-zed.yml
@@ -33,7 +33,6 @@ infrastructure_projects:
   openstack-base:
   openvswitch:
   ovn:
-  ovsdpdk:
   prometheus:
   rabbitmq:
   redis:


### PR DESCRIPTION
This way we're able to already build ovs images with our own openvswitch packages.