### PR TITLE
zed: remove ovsdpdk for the moment (again)

### DIFF
--- a/latest/openstack-zed.yml
+++ b/latest/openstack-zed.yml
@@ -33,7 +33,6 @@ infrastructure_projects:
   openstack-base:
   openvswitch:
   ovn:
-  ovsdpdk:
   prometheus:
   rabbitmq:
   redis:


### PR DESCRIPTION
Since we now want to work with Open vSwitch 3.1.0, we would first have to disable DPDK again.