### PR TITLE
5.1.0: do not build ovsdpdk images

### DIFF
--- a/5.1.0/openstack-zed.yml
+++ b/5.1.0/openstack-zed.yml
@@ -33,7 +33,6 @@ infrastructure_projects:
   openstack-base:
   openvswitch:
   ovn:
-  ovsdpdk:
   prometheus:
   rabbitmq:
   redis:


### PR DESCRIPTION
Not possible with the new OVS 3.1 packages at the moment.