### PR TITLE
Registries: Change zuul registry to quay.io. Unfortunately the org name changed.

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -45,12 +45,12 @@ squid: ubuntu/squid
 # zuul
 
 zookeeper: library/zookeeper
-zuul_client: zuul/zuul-client
-zuul_executor: zuul/zuul-executor
-zuul_nodepool_builder: zuul/nodepool-builder
-zuul_nodepool_launcher: zuul/nodepool-launcher
-zuul_scheduler: zuul/zuul-scheduler
-zuul_web: zuul/zuul-web
+zuul_client: zuul-ci/zuul-client
+zuul_executor: zuul-ci/zuul-executor
+zuul_nodepool_builder: zuul-ci/nodepool-builder
+zuul_nodepool_launcher: zuul-ci/nodepool-launcher
+zuul_scheduler: zuul-ci/zuul-scheduler
+zuul_web: zuul-ci/zuul-web
 
 # other
 


### PR DESCRIPTION
Information from zuul-announce@lists.zuul-ci.org from 2023-04-27 22:14 CEST

depends: osism/ansible-defaults#123

Signed-off-by: Tim Beermann <beermann@osism.tech>
