### PR TITLE
Revert "chore(deps): update dependency moby/moby to v20.10.25"

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -13,7 +13,7 @@ osism_projects:
   # renovate: datasource=docker depName=quay.io/osism/ara-server
   ara: '1.6.1'
   # renovate: datasource=github-releases depName=moby/moby
-  docker: '5:20.10.25'
+  docker: '5:20.10.24'
   # renovate: datasource=pypi depName=osism
   osism: '0.20230718.0'
   # renovate: datasource=github-releases depName=k3s-io/k3s


### PR DESCRIPTION
This reverts commit 0506907526ead43b33756b52769165b4ba028687.

v20.10.25 is still not available as a package.