### PR TITLE
latest: remove zuul versions

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -71,18 +71,6 @@ docker_images:
   vault: '1.14.2'
   # renovate: datasource=docker depName=zookeeper
   zookeeper: '3.8.2'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/zuul.git
-  zuul_client: '8.3.1'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/zuul.git
-  zuul_executor: '8.3.1'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/nodepool.git
-  zuul_nodepool_builder: '8.2.0'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/nodepool.git
-  zuul_nodepool_launcher: '8.2.0'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/zuul.git
-  zuul_scheduler: '8.3.1'
-  # renovate: datasource=git-tags depName=https://opendev.org/zuul/zuul.git
-  zuul_web: '8.3.1'
 
 ansible_roles:
   geerlingguy.certbot: master


### PR DESCRIPTION
We do not use Zuul in deployments. It is an external service. Therefore, the version of Zuul used does not need to be listed in osism/release. The version used is independent of a release.