### PR TITLE
Revert "7.0.0a: use RabbitMQ quorum queues (#1213)"

### DIFF
--- a/doc/source/notes/7.0.0a.rst
+++ b/doc/source/notes/7.0.0a.rst
@@ -28,14 +28,6 @@ Housekeeping
 Upgrade notes
 =============
 
-* The use of RabbitMQ quorum queues is now possible and recommended. The parameter
-  ``om_enable_rabbitmq_quorum_queues`` is added to ``environments/kolla/configuration.yml``
-  for this purpose.
-
-  .. code-block:: yaml
-
-     om_enable_rabbitmq_quorum_queues: yes
-
 * The use of ProxySQL for MariaDB is now possible and it is recommended to switch
   to it as part of the upgrade. The parameter ``enable_proxysql`` is added to
   ``environments/kolla/configuration.yml`` for this purpose.


### PR DESCRIPTION
This reverts commit 2690b5e398f881012457e42c18b39c69384b8572.