### PR TITLE
latest: disable senlin 2024.1

### DIFF
--- a/latest/openstack-2024.1.yml
+++ b/latest/openstack-2024.1.yml
@@ -58,7 +58,7 @@ openstack_projects:
   nova: stable-2024.1
   octavia: stable-2024.1
   placement: stable-2024.1
-  senlin: stable-2024.1
+  # senlin: stable-2024.1
   skyline-apiserver: stable-2024.1
   skyline-console: stable-2024.1
   # swift: stable-2024.1


### PR DESCRIPTION
There is no senlin 2024.1 release.

Related to ee34dabdbce1a1ee6df019e718abd2131775aa58