### PR TITLE
latest: use renovate to update openstack ansible-core version

### DIFF
--- a/latest/openstack-2023.2.yml
+++ b/latest/openstack-2023.2.yml
@@ -1,6 +1,7 @@
 ---
 ansible_version: '>=9.0.0,<10.0.0'
-ansible_core_version: '2.16.4'
+# renovate: datasource=pypi depName=ansible-core
+ansible_core_version: '2.16.6'
 
 openstack_version: "2023.2"
 openstack_previous_version: "2023.1"

--- a/latest/openstack-2024.1.yml
+++ b/latest/openstack-2024.1.yml
@@ -1,6 +1,7 @@
 ---
 ansible_version: '>=9.0.0,<10.0.0'
-ansible_core_version: '2.16.4'
+# renovate: datasource=pypi depName=ansible-core
+ansible_core_version: '2.16.6'
 
 openstack_version: "2024.1"
 openstack_previous_version: "2023.2"


### PR DESCRIPTION
Only the versions that can also use the latest Ansible core.