### PR TITLE
latest: use renovate to update ceph ansible-core version

### DIFF
--- a/latest/ceph-reef.yml
+++ b/latest/ceph-reef.yml
@@ -1,6 +1,7 @@
 ---
 ansible_version: ">=9.0.0,<10.0.0"
-ansible_core_version: '2.16.4'
+# renovate: datasource=pypi depName=ansible-core
+ansible_core_version: '2.16.6'
 
 ceph_ansible_version: stable-8.0
 ceph_container_version: stable-8.0


### PR DESCRIPTION
Only the versions that can also use the latest Ansible core.