### PR TITLE
7.1.1: use docker 26.1.4 by default

### DIFF
--- a/7.1.1/base.yml
+++ b/7.1.1/base.yml
@@ -11,7 +11,7 @@ playbooks_version: 'v0.20240812.0'
 
 osism_projects:
   ara: '1.7.1'
-  docker: '5:24.0.9'
+  docker: '5:26.1.4'
   osism: '0.20240812.0'
   k3s: 'v1.30.3+k3s1'
 


### PR DESCRIPTION
Required because of Ubuntu 24.04 support. Only Docker >= 26.0.0 available there.