### PR TITLE
latest: back to ansible 2.15 for ceph quincy

### DIFF
--- a/latest/ceph-quincy.yml
+++ b/latest/ceph-quincy.yml
@@ -1,6 +1,6 @@
 ---
-ansible_version: ">=9.0.0,<10.0.0"
-ansible_core_version: '2.16.10'
+ansible_version: ">=8.0.0,<9.0.0"
+ansible_core_version: '2.15.12'
 
 ceph_ansible_version: stable-7.0
 ceph_container_version: stable-7.0


### PR DESCRIPTION
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.