### PR TITLE
latest: remove helm_chart_repositories

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -135,11 +135,3 @@ ansible_collections:
   osism.validations: main
   # renovate: datasource=galaxy-collection depName=purestorage.flasharray
   purestorage.flasharray: '1.34.0'
-
-helm_chart_repositories:
-  bitnami: https://charts.bitnami.com/bitnami
-  cnpg: https://cloudnative-pg.github.io/charts
-  codecentric: https://codecentric.github.io/helm-charts
-  dnationcloud: https://dnationcloud.github.io/helm-hub
-  mariadb-operator: https://mariadb-operator.github.io/mariadb-operator
-  rook-release: https://charts.rook.io/release


### PR DESCRIPTION
They are now part of osism-kubernetes.