### PR TITLE
renovate: enable ansible minor/patch updates for stable releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -66,6 +66,21 @@
         "latest/openstack-2024.1.yml",
         "latest/openstack-2024.2.yml"
       ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
+    },
+    {
+      "matchDepNames": [
+        "ansible",
+        "ansible-core"
+      ],
+      "matchFileNames": [
+        "latest/ceph-quincy.yml",
+        "latest/ceph-reef.yml",
+        "latest/openstack-2023.2.yml",
+        "latest/openstack-2024.1.yml",
+        "latest/openstack-2024.2.yml"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
Enable minor and patch updates for ansible and ansible-core dependencies in stable Ceph (quincy, reef) and OpenStack (2023.2, 2024.1, 2024.2) release files to ensure security patches and bug fixes are applied.