### PR TITLE
renovate: restrict Ansible updates to patch versions only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,7 +64,7 @@
         "latest/openstack-2024.1.yml",
         "latest/openstack-2024.2.yml"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
@@ -78,7 +78,7 @@
         "latest/openstack-2024.1.yml",
         "latest/openstack-2024.2.yml"
       ],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {


### PR DESCRIPTION
- 2.18.4 -> 2.18.5: OK
- 2.17.2 -> 2.17.3: OK
- 2.17.2 -> 2.18.5: NOT OK