### PR TITLE
Revert "chore(deps): update ansible (#2100)"

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -2,9 +2,9 @@
 manager_version: latest
 
 # renovate: datasource=pypi depName=ansible
-ansible_version: '11.8.0'
+ansible_version: '11.7.0'
 # renovate: datasource=pypi depName=ansible-core
-ansible_core_version: '2.19.0'
+ansible_core_version: '2.18.7'
 
 # renovate: datasource=github-tags depName=osism/defaults
 defaults_version: 'v0.20250711.0'


### PR DESCRIPTION
This reverts commit f2525a6de69d1ecca410ea5949eec25373f524e3.

Something is broken with the fact caching in ansible-core 2.19.0.