### PR TITLE
Clean up obsolete, pypi based renovate configs for ansible and ara

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,26 +10,6 @@
         "/^latest\\/base.yml$/"
       ],
       "matchStrings": [
-        "(?<depName>ansible)_version: '(?<currentValue>.*?)'"
-      ],
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^latest\\/base.yml$/"
-      ],
-      "matchStrings": [
-        "(?<depName>ara): '(?<currentValue>.*?)'"
-      ],
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^latest\\/base.yml$/"
-      ],
-      "matchStrings": [
         "# renovate: datasource=(?<datasource>github-releases) depName=(?<depName>.*?)\n.*?docker: '5:(?<currentValue>.*?)'"
       ],
       "extractVersionTemplate": "^v(?<version>.*)$"


### PR DESCRIPTION
The dedicated custom managers for ara (pypi datasource) and
ansible (pypi datasource) predate the generic comment-based
regex manager introduced in commit 3b2aa9c. They were never
cleaned up during that refactoring.
