### PR TITLE
renovate: register latest/openstack-2025.2.yml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,8 @@
         "/^latest\\/ceph-squid.yml$/",
         "/^latest\\/openstack-2024.1.yml$/",
         "/^latest\\/openstack-2024.2.yml$/",
-        "/^latest\\/openstack-2025.1.yml$/"
+        "/^latest\\/openstack-2025.1.yml$/",
+        "/^latest\\/openstack-2025.2.yml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>docker) depName=(?<depName>.*?)\n.*?: '(?<currentValue>.*?)'",
@@ -46,7 +47,8 @@
         "latest/ceph-squid.yml",
         "latest/openstack-2024.1.yml",
         "latest/openstack-2024.2.yml",
-        "latest/openstack-2025.1.yml"
+        "latest/openstack-2025.1.yml",
+        "latest/openstack-2025.2.yml"
       ],
       "matchUpdateTypes": [
         "patch"
@@ -65,7 +67,8 @@
         "latest/ceph-squid.yml",
         "latest/openstack-2024.1.yml",
         "latest/openstack-2024.2.yml",
-        "latest/openstack-2025.1.yml"
+        "latest/openstack-2025.1.yml",
+        "latest/openstack-2025.2.yml"
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
## Summary

`latest/openstack-2025.2.yml` was added on 2026-01-30 with the same annotation set as `latest/openstack-2025.1.yml` (`ansible_version`, `ansible-core`, `defaults_version`, `generics_version`, etc.) but was never registered in `.github/renovate.json`. As a result, the sibling `2025.1` file has been bumped ~10 times since (last 2026-04-18) while `2025.2` has had **zero** Renovate activity. Anything targeting 2025.2 currently ships with a three-month-stale dep set.

This change mirrors the treatment `2025.1` already gets by adding `latest/openstack-2025.2.yml` in the three places `2025.1` is referenced:

- `customManagers[0].managerFilePatterns`
- `packageRules[0].matchFileNames` (the `ansible` patch group, `enabled: true`)
- `packageRules[1].matchFileNames` (the `ansible` major/minor disable, `enabled: false`)

The Ceph- and base-specific rules don't apply to an `openstack-*` file and are intentionally left untouched.

## Acceptance

- [ ] The Renovate Dependency Dashboard for `osism/release` lists `latest/openstack-2025.2.yml` under `Detected Dependencies` with the same dep entries as `2025.1`.
- [ ] The next Renovate run produces bumps for `2025.2` that mirror the recent `2025.1` activity (or rate-limited entries; either is correct).

## Test plan

- [ ] JSON validates (`python3 -m json.tool .github/renovate.json`) — done locally.
- [ ] After merge: confirm Dependency Dashboard reflects new file.
- [ ] After merge: confirm subsequent Renovate runs open PRs / rate-limit entries for `2025.2`.