### PR TITLE
actions: automatically add all opened issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add issues and PRs to project boards
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+permissions: read-all
+
+jobs:
+  add-to-project-boards:
+    uses: osism/osism.github.io/.github/workflows/add-to-project.yml@26f84f8d6cdfd6b7e2fc6bfa85be4ee059158099


### PR DESCRIPTION
* this action should run whenever issues or PRs are opened and should add them to either the "Bot Board" if they are created by bots (based on their label, e.g. renovate) or to the "Human Board"
* upstream action: https://github.com/actions/add-to-project
* the latest release of the action is currently v1.0.2 from mid 2024 so we can't really use this here to pin the version, but instead reference by commit (currently latest from main)

_Mirrors osism/osism.github.io#988 (26f84f8d)._