### PR TITLE
latest: pin kolla_ansible docker image tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -132,6 +132,11 @@
         "latest/base.yml"
       ],
       "groupName": "osism"
+    },
+    {
+      "matchDepNames": ["registry.osism.tech/osism/kolla-ansible"],
+      "matchFileNames": ["latest/base.yml"],
+      "allowedVersions": "/^0\\.\\d{8}\\.\\d+$/"
     }
   ]
 }

--- a/latest/base.yml
+++ b/latest/base.yml
@@ -44,6 +44,8 @@ docker_images:
   homer: 'v25.11.1'
   # renovate: datasource=docker depName=registry.osism.tech/osism/inventory-reconciler
   inventory_reconciler: '0.20260322.0'
+  # renovate: datasource=docker depName=registry.osism.tech/osism/kolla-ansible
+  kolla_ansible: '0.20260328.0'
   # renovate: datasource=docker depName=fleetdm/fleet
   fleet: 'v4.85.1'
   # renovate: datasource=docker depName=registry.osism.tech/osism/gnmic


### PR DESCRIPTION
## Summary

- Adds `docker_images.kolla_ansible: '0.20260328.0'` to `latest/base.yml` with a `datasource=docker` Renovate annotation
- Adds an `allowedVersions` package rule to `.github/renovate.json` restricting Renovate to stable date-based tags (`0.YYYYMMDD.N`), preventing proposals of rolling OpenStack tags like `2025.1`

This is the release-side half of a two-repo fix for `kolla/release/2025.1/fluentd:2025.1 not found` 500 errors in `testbed-upgrade-stable-next-ubuntu-24.04`. Without this entry, `generics/environments/manager/images.yml` fell into a `manager_version == 'latest'` bypass that resolved `kolla_ansible_tag` to `openstack_version` rather than the pinned date-stamped tag.

**Must be merged before** osism/generics#595.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('latest/base.yml'))"` passes
- [x] `python3 -c "import json; json.load(open('.github/renovate.json'))"` passes
- [ ] After both PRs merge: `MANAGER_VERSION=latest tox -e test` in generics produces `kolla_ansible_tag: 0.20260328.0`