### PR TITLE
Prepare 10.1.0 release

### DIFF
--- a/10.1.0/base.yml
+++ b/10.1.0/base.yml
@@ -1,0 +1,82 @@
+---
+manager_version: 10.1.0
+ansible_version: 11.10.0
+ansible_core_version: 2.18.9
+defaults_version: v0.20260526.0
+generics_version: v0.20260615.0
+manager_playbooks_version: v0.20260615.0
+operations_version: v0.20250530.0
+playbooks_version: v0.20260615.0
+osism_projects:
+  ara: 1.7.5
+  docker: 5:27.5.1
+  osism: 0.20260615.0
+  k3s: v1.34.2+k3s1
+docker_images:
+  adminer: 5.4.2
+  alerta: 9.1.0
+  ara_server: 1.7.5
+  cgit: 1.2.3
+  dnsdist: 1.9.8
+  dnsmasq: '2.91'
+  homer: v25.11.1
+  inventory_reconciler: 0.20260615.0
+  fleet: v4.86.2
+  gnmic: 0.41.0
+  mariadb: 11.8.4
+  memcached: 1.6.39-alpine
+  netbox: v4.3.5
+  nexus: 3.89.0
+  nginx: 1.29.3-alpine
+  osism: 0.20260615.0
+  osism_ansible: 0.20260615.0
+  osism_kubernetes: 0.20260615.0
+  opentelemetry_collector: 0.154.0
+  pgautoupgrade: 16-alpine
+  phpmyadmin: 5.2.3
+  pushgateway: v1.11.3
+  postgres: 16.11-alpine
+  redis: 7.4.7-alpine
+  registry: '3.0'
+  scaphandre: 1.0.2
+  squid: 6.1-23.10_beta
+  stepca: 0.30.2
+  syft: v1.45.1
+  openstack_database_exporter: v1.1.0
+  tempest: latest
+  traefik: v3.5.0
+  sonic_vs: latest
+  substation: latest
+  vault: 1.21.4
+  kolla_ansible: 0.20260615.0
+  ceph_ansible: 0.20260615.0
+  kolla: 0.20260328.0
+ansible_roles:
+  geerlingguy.certbot: master
+  geerlingguy.dotfiles: master
+  hardening: e77c311442cb1d1ef8caa7df9d9c00471afa75e7
+  pdns_recursor: v1.8.1
+  ubuntu22_cis: 2.0.3
+ansible_collections:
+  ansible.netcommon: 8.5.2
+  ansible.posix: 2.2.0
+  ansible.utils: 6.0.2
+  cloud.common: 5.0.0
+  community.crypto: 3.2.2
+  community.docker: 5.2.1
+  community.general: 11.4.9
+  community.grafana: 2.3.0
+  community.hashi_vault: 7.1.0
+  community.mysql: 4.3.0
+  community.network: 5.1.0
+  community.rabbitmq: 1.6.0
+  community.zabbix: 4.2.0
+  containers.podman: 1.20.2
+  debops.debops: 3.3.0
+  fortinet.fortios: 2.5.1
+  netbox.netbox: 3.23.0
+  openstack.cloud: 2.5.0
+  osism.commons: 0.20260601.0
+  osism.services: 0.20260615.0
+  osism.validations: 0.20260615.0
+  purestorage.flasharray: 1.42.0


### PR DESCRIPTION
Add the release definition (`10.1.0/base.yml`) for the OSISM 10.1.0 release.

Closes #2509