### PR TITLE
Build valkey image in 2025.1 and 2025.2

### DIFF
--- a/latest/openstack-2025.1.yml
+++ b/latest/openstack-2025.1.yml
@@ -41,6 +41,7 @@ infrastructure_projects:
   rabbitmq:
   redis:
   tgtd:
+  valkey:
 
 openstack_projects:
   aodh: stable-2025.1

--- a/latest/openstack-2025.2.yml
+++ b/latest/openstack-2025.2.yml
@@ -41,6 +41,7 @@ infrastructure_projects:
   rabbitmq:
   redis:
   tgtd:
+  valkey:
 
 openstack_projects:
   aodh: stable-2025.2


### PR DESCRIPTION
valkey is enabled in OSISM (`enable_valkey` is truthy in osism/defaults `all/099-kolla.yml`) and buildable upstream — openstack/kolla ships a `docker/valkey` directory at both `stable/2025.1` and `stable/2025.2` — but the release build set never lists valkey under `infrastructure_projects`, so no valkey image is built for either release. Downstream of that, the `versions['valkey']` pin read by the kolla-ansible template can never resolve to a built image.

This adds `valkey` to `infrastructure_projects` in `latest/openstack-2025.1.yml` and `latest/openstack-2025.2.yml`, closing the **enabled → built** gap surfaced by the image-drift detector (`kolla_enablement_build`).

Wiring the version pin itself is a separate, companion change in container-images-kolla (`SBOM_IMAGE_TO_VERSION`):

- osism/container-images-kolla#745