### PR TITLE
Track ara pip package via pypi datasource

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -18,7 +18,7 @@ operations_version: 'v0.20250530.0'
 playbooks_version: 'v0.20260615.0'
 
 osism_projects:
-  # renovate: datasource=docker depName=registry.osism.tech/osism/ara-server
+  # renovate: datasource=pypi depName=ara
   ara: '1.7.5'
   # renovate: datasource=github-releases depName=moby/moby
   docker: '5:27.5.1'


### PR DESCRIPTION
## Problem

`osism_projects.ara` in `latest/base.yml` pins the **pip**-installed ara
version (`ara==1.7.5` in `python-osism/requirements.txt`), but its Renovate
annotation pointed at the **docker** datasource
`registry.osism.tech/osism/ara-server`. That only worked while the container
tag and the PyPI release shared the same version string.

Now that:

- osism/container-images#942 tags `ara-server` with a downstream revision
  (`1.7.5-r1`) so OSISM rebuilds mint a fresh immutable tag without an
  upstream version bump, and
- osism/renovate-config#8 teaches Renovate to read that `-rN` revision,

the shared annotation made Renovate bump **both** entries — see #2555, which
pushes `osism_projects.ara` to `1.7.5-r1`. That version does not exist on
PyPI and would break the pip install.

## Change

Point the `osism_projects.ara` annotation at `datasource=pypi depName=ara` so
the pip version tracks PyPI independently and never picks up the docker
image's `-rN` revision. The `docker_images.ara_server` entry keeps the docker
annotation and is bumped to `1.7.5-r1` separately.

Once this merges, #2555 can be rebased and will collapse to just the
legitimate `ara_server: 1.7.5-r1` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
