### PR TITLE
Archive backend: fetch repos as tarballs for remote drift runs

### DIFF
--- a/src/osism_drift/archive.py
+++ b/src/osism_drift/archive.py
@@ -1,0 +1,76 @@
+import atexit
+import io
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+from osism_drift.http import SourceError, _get
+
+
+def _repo_slug(repo):
+    # GitHub repo names are hyphenated; every remote URL applies this.
+    return repo.replace("_", "-")
+
+
+def _archive_url(github_api, owner, repo, ref):
+    return f"{github_api}{owner}/{_repo_slug(repo)}/tarball/{ref}"
+
+
+def _fetch_archive_bytes(repo, ref, url):
+    """GET the tarball via the shared _get (auth + error handling), retry once.
+    200 -> bytes; 404 -> SourceError (ref was expected to exist)."""
+    last = None
+    for attempt in (1, 2):
+        try:
+            r = _get("fetching archive", url, ok=(404,), timeout=60)
+        except SourceError as e:
+            last = e
+            continue  # transport / non-ok: retry once, then re-raise below
+        if r.status_code == 404:
+            raise SourceError(f"no archive for {repo}@{ref}")
+        return r.content
+    raise last
+
+
+def _safe_extract(data, dest):
+    """Extract a .tar.gz into dest, rejecting anything that could escape it."""
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        if hasattr(tarfile, "data_filter"):
+            try:
+                tar.extractall(dest, filter="data")
+            except tarfile.FilterError as e:
+                raise SourceError(f"unsafe archive member: {e}") from e
+        else:
+            for m in tar.getmembers():
+                target = (dest / m.name).resolve()
+                root = dest.resolve()
+                if target != root and root not in target.parents:
+                    raise SourceError(f"unsafe archive member path: {m.name}")
+                if not (m.isfile() or m.isdir()):
+                    raise SourceError(f"unsafe archive member (link/special): {m.name}")
+            tar.extractall(dest)
+
+
+def _extract_snapshot(data, repo, ref):
+    tmp = Path(tempfile.mkdtemp(prefix="osism-drift-"))
+    atexit.register(shutil.rmtree, tmp, ignore_errors=True)
+    _safe_extract(data, tmp)
+    # GitHub archives contain a single top-level directory; return it.
+    entries = list(tmp.iterdir())
+    if len(entries) == 1 and entries[0].is_dir():
+        return entries[0]
+    return tmp
+
+
+def snapshot_dir(owner, repo, ref, config):
+    """Extracted-tree Path for (repo, ref); fetched+extracted once, then memoized."""
+    key = (config.remote.github_api, owner, _repo_slug(repo), ref)
+    cached = config.snapshot_cache.get(key)
+    if cached is not None:
+        return cached
+    url = _archive_url(config.remote.github_api, owner, repo, ref)
+    data = _fetch_archive_bytes(repo, ref, url)
+    root = _extract_snapshot(data, repo, ref)
+    config.snapshot_cache[key] = root
+    return root

--- a/src/osism_drift/config.py
+++ b/src/osism_drift/config.py
@@ -63,6 +63,10 @@ class Config:  # pylint: disable=too-many-instance-attributes  # data record
     ref_cache: dict = field(
         default_factory=dict
     )  # per-run release_to_ref memo (runtime state)
+    archive: bool = False  # driver sets True (archive reads); --use-raw-get keeps False
+    snapshot_cache: dict = field(
+        default_factory=dict
+    )  # per-run (github_api, owner, slug, ref) -> extracted Path
 
 
 def load_config(path) -> Config:

--- a/src/osism_drift/driver.py
+++ b/src/osism_drift/driver.py
@@ -65,6 +65,15 @@ def run(
         )
         for line in resolution:
             print(line, file=sys.stderr)
+        # Remote reads go through the GitHub API, which is slow: a full run makes
+        # dozens of requests over several minutes. Warn up front and stream one
+        # line per request, so the wait looks like progress rather than a hang.
+        if any(" remote " in line for line in resolution):
+            print(
+                "GitHub API reads can take several minutes; progress follows.",
+                file=sys.stderr,
+            )
+            source.set_progress(lambda line: print(line, file=sys.stderr, flush=True))
 
     drifts = []
     try:

--- a/src/osism_drift/driver.py
+++ b/src/osism_drift/driver.py
@@ -172,6 +172,12 @@ def _build_parser(plugin_groups, description, default_config, default_allowlist)
             "of erroring"
         ),
     )
+    p.add_argument(
+        "--use-raw-get",
+        action="store_true",
+        help="fetch repo files one raw GET at a time instead of per-(repo,ref) "
+        "archive tarballs (slower; more requests; only if the archive backend misbehaves)",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     p.add_argument("-q", "--quiet", action="store_true")
     return p
@@ -229,6 +235,7 @@ def _load_runtime(args):
         config,
         base_dirs=tuple(args.base_dir or ()),
         remote_fallback=args.remote_fallback,
+        archive=not args.use_raw_get,
     )
     allowlist = (
         Allowlist(entries=()) if args.no_allowlist else load_allowlist(args.allowlist)

--- a/src/osism_drift/driver.py
+++ b/src/osism_drift/driver.py
@@ -65,14 +65,23 @@ def run(
         )
         for line in resolution:
             print(line, file=sys.stderr)
-        # Remote reads go through the GitHub API, which is slow: a full run makes
-        # dozens of requests over several minutes. Warn up front and stream one
-        # line per request, so the wait looks like progress rather than a hang.
+        # Remote reads either download one archive per (repo, ref) and serve
+        # files locally (the default), or -- with --use-raw-get -- fetch each
+        # file via the GitHub API, which is slow: dozens of requests over several
+        # minutes. Either way, stream one line per read so the wait looks like
+        # progress rather than a hang, with a mode-appropriate heads-up.
         if any(" remote " in line for line in resolution):
-            print(
-                "GitHub API reads can take several minutes; progress follows.",
-                file=sys.stderr,
-            )
+            if config.archive:
+                print(
+                    "Downloading one repo archive per repo/ref; "
+                    "reads then run locally.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "GitHub API reads can take several minutes.",
+                    file=sys.stderr,
+                )
             source.set_progress(lambda line: print(line, file=sys.stderr, flush=True))
 
     drifts = []

--- a/src/osism_drift/http.py
+++ b/src/osism_drift/http.py
@@ -1,0 +1,125 @@
+"""Shared HTTP transport and error-handling layer for remote source reads."""
+
+import datetime
+import os
+from urllib.parse import urlparse
+
+import requests
+
+
+class SourceError(Exception):
+    """Raised on any read/list failure that should abort the run."""
+
+
+_GITHUB_HOSTS = frozenset({"github.com", "api.github.com", "raw.githubusercontent.com"})
+
+
+def _auth_headers(url: str, extra: dict | None = None) -> dict:
+    """Merge a GitHub bearer token into request headers when one is available
+    AND `url` targets a public GitHub host.
+
+    Reads GITHUB_TOKEN (then GH_TOKEN) from the environment. When set and the
+    request goes to a GitHub host, the read is authenticated, lifting GitHub's
+    unauthenticated 60/hr per-IP limit to 5000/hr; otherwise behaviour is
+    unchanged (unauthenticated). Gating on the host keeps a token configured for
+    github.com from leaking to a non-GitHub github_raw/github_api override. The
+    Zuul periodic-daily job carries no token today, so this is a no-op there and
+    a win for local/developer and any future authenticated runs.
+    """
+    headers = dict(extra or {})
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token and (urlparse(url).hostname or "") in _GITHUB_HOSTS:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _rate_limit_hint(r) -> str | None:
+    """A helpful hint when response `r` is a GitHub rate-limit rejection, else None.
+
+    GitHub reports its primary rate limit as HTTP 403 (or, more recently, 429)
+    with X-RateLimit-Remaining: 0, and secondary limits as 403/429 with a
+    Retry-After header. Unauthenticated requests share a low per-IP hourly
+    budget that a full remote drift run can exhaust; a token lifts it (see
+    _auth_headers), so the actionable advice differs by auth state. The exact
+    quotas are not hardcoded here (GitHub changes them, and this string is read
+    whenever the script runs, not when it was written): the actual limit in
+    effect is echoed from the response's X-RateLimit-Limit header. A 403 without
+    those markers is some other refusal (auth/permission), not throttling, and
+    gets no hint.
+
+    Separately, raw.githubusercontent.com (a Fastly CDN serving file bytes, the
+    bulk of a remote run) throttles per-IP and returns 429 with none of those
+    headers; that markerless 429 gets its own hint pointing at --base-dir, since
+    a token does not draw the raw host from the API budget.
+    """
+    if r.status_code not in (403, 429):
+        return None
+    retry_after = r.headers.get("Retry-After")
+    if r.headers.get("X-RateLimit-Remaining") != "0" and retry_after is None:
+        # No GitHub-API rate-limit markers. raw.githubusercontent.com is a Fastly
+        # CDN that throttles per-IP and returns 429 with none of these headers, so
+        # a markerless 429 is CDN throttling (the API path always carries a marker)
+        # and still deserves an actionable hint. A markerless 403, by contrast, is
+        # an ordinary auth/permission refusal, not throttling, and gets none.
+        if r.status_code == 429:
+            return (
+                "raw.githubusercontent.com throttled this request. Its rate limit "
+                "is per-IP, intermittent, and separate from the GitHub API budget "
+                "(a token may raise the anonymous tier but won't guarantee relief). "
+                "Prefer local checkouts (--base-dir) to avoid remote fetches, retry "
+                "later, or run from a different network."
+            )
+        return None
+    parts = ["GitHub API rate limit hit."]
+    limit = r.headers.get("X-RateLimit-Limit")
+    quota = f" (limit in effect: {limit}/hr)" if limit and limit.isdigit() else ""
+    reset = r.headers.get("X-RateLimit-Reset")
+    if retry_after and retry_after.isdigit():
+        parts.append(f"Retry after {retry_after}s.")
+    elif reset and reset.isdigit():
+        when = datetime.datetime.fromtimestamp(
+            int(reset), datetime.timezone.utc
+        ).strftime("%Y-%m-%d %H:%M UTC")
+        parts.append(f"Limit resets at {when}.")
+    if os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"):
+        parts.append(
+            f"This run is authenticated{quota}; wait for the reset or reduce "
+            "concurrency."
+        )
+    else:
+        parts.append(
+            f"This run is unauthenticated{quota}; set GITHUB_TOKEN (or GH_TOKEN) "
+            "to use the much higher authenticated limit."
+        )
+    return " ".join(parts)
+
+
+def _http_error(action: str, url: str, r) -> SourceError:
+    """SourceError for a non-ok HTTP response, with a rate-limit hint appended
+    when the response looks like GitHub throttling rather than a plain failure."""
+    msg = f"HTTP {r.status_code} {action} {url}"
+    hint = _rate_limit_hint(r)
+    if hint:
+        msg = f"{msg} — {hint}"
+    return SourceError(msg)
+
+
+_GH_JSON = {"Accept": "application/vnd.github.v3+json"}
+
+
+def _get(action: str, url: str, *, json_api: bool = False, ok=(), timeout: int = 30):
+    """GET `url` with auth + a timeout; return the Response.
+
+    `json_api` sends the GitHub REST Accept header. A transport failure, or a
+    non-ok status whose code is not in `ok`, raises SourceError (with a
+    rate-limit hint via _http_error); the caller keeps its own handling for the
+    codes it whitelists (e.g. a 404 that means "absent", not "failed").
+    """
+    extra = _GH_JSON if json_api else None
+    try:
+        r = requests.get(url, timeout=timeout, headers=_auth_headers(url, extra))
+    except requests.RequestException as e:
+        raise SourceError(f"network error {action} {url}: {e}") from e
+    if not r.ok and r.status_code not in ok:
+        raise _http_error(action, url, r)
+    return r

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -18,6 +18,32 @@ class SourceError(Exception):
     """Raised on any read/list failure that should abort the run."""
 
 
+# Progress sink for remote reads. A remote drift run makes dozens of GitHub
+# requests over minutes with no other output, which reads as "hung" and invites
+# an impatient Ctrl-C. The driver installs a sink (unless --quiet) so each read
+# prints a short activity line; the default is a no-op, keeping library and test
+# callers silent. Only remote branches reach _note(), so local runs stay quiet.
+_progress = None
+_calls = 0
+
+
+def set_progress(sink) -> None:
+    """Install a callable(line:str) to receive one line per remote read."""
+    global _progress, _calls
+    _progress = sink
+    _calls = 0
+
+
+def _note(kind: str, repo: str, ref: str, detail: str = "") -> None:
+    """Emit one short progress line for a remote read (no-op without a sink)."""
+    global _calls
+    _calls += 1
+    if _progress is None:
+        return
+    loc = f"{repo}:{detail}" if detail else repo
+    _progress(f"  [{_calls:>3}] {kind:<5} {loc} @ {ref}")
+
+
 # Hosts the GitHub bearer token may be sent to. github_raw/github_api are
 # configurable (a mirror, proxy, or test server), so the token is attached only
 # when the actual request host is public GitHub -- an ambient GITHUB_TOKEN must
@@ -260,6 +286,7 @@ def read(repo: str, rel_path: str, config) -> bytes:
             raise SourceError(f"{rel_path} not found in local {repo} ({d})")
         return p.read_bytes()
     url = _remote_url(repo, rel_path, config)
+    _note("raw", repo, _ref(repo, config), rel_path)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -275,6 +302,7 @@ def read_optional(repo: str, rel_path: str, config) -> bytes | None:
         p = d / rel_path
         return p.read_bytes() if p.exists() else None
     url = _remote_url(repo, rel_path, config)
+    _note("raw", repo, _ref(repo, config), rel_path)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         return None
@@ -318,6 +346,7 @@ def list_tree(repo: str, rel_path: str, config, missing_ok: bool = False) -> lis
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"git/trees/{_ref(repo, config)}?recursive=1"
     )
+    _note("tree", repo, _ref(repo, config), rel_path)
     r = _get("listing tree", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         if missing_ok:
@@ -346,6 +375,7 @@ def list_dir(repo: str, rel_path: str, config, dirs_only: bool = False) -> list[
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={_ref(repo, config)}"
     )
+    _note("list", repo, _ref(repo, config), rel_path)
     r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -374,6 +404,7 @@ def list_dir_at_ref(
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={ref}"
     )
+    _note("list", repo, ref, rel_path)
     r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -391,6 +422,7 @@ def ref_exists(repo: str, ref: str, config) -> bool:
         return _git_ref_exists(d, ref)
     owner = _owner(repo, config)
     url = f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/commits/{ref}"
+    _note("ref?", repo, ref)
     r = _get("checking ref", url, json_api=True, ok=(404, 422))
     # GitHub's commits API returns 422 (not 404) for a ref that does not
     # resolve; treat both as "absent" so the resolver probes the next candidate.
@@ -449,6 +481,7 @@ def read_at_ref(
         f"{config.remote.github_raw}{owner}/{repo.replace('_', '-')}/"
         f"{ref}/{rel_path}"
     )
+    _note("raw", repo, ref, rel_path)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         if optional:

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -8,6 +8,7 @@ result is deterministic regardless of any local checkout's current branch.
 import subprocess
 from pathlib import Path
 
+from osism_drift import archive
 from osism_drift.http import SourceError, _get
 
 # Re-exported so callers/tests reach the transport layer via osism_drift.source
@@ -212,8 +213,12 @@ def read(repo: str, rel_path: str, config) -> bytes:
         if _is_pinned(repo, config):
             return _git_show(d, _ref(repo, config), rel_path)
         return _dir_read(d, rel_path, f"local {repo} ({d})")
-    url = _remote_url(repo, rel_path, config)
     _note("raw", repo, _ref(repo, config), rel_path)
+    if config.archive:
+        ref = _ref(repo, config)
+        d = archive.snapshot_dir(_owner(repo, config), repo, ref, config)
+        return _dir_read(d, rel_path, f"{repo}@{ref} snapshot")
+    url = _remote_url(repo, rel_path, config)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -227,8 +232,12 @@ def read_optional(repo: str, rel_path: str, config) -> bytes | None:
         if _is_pinned(repo, config):
             return _git_show(d, _ref(repo, config), rel_path, optional=True)
         return _dir_read_optional(d, rel_path)
-    url = _remote_url(repo, rel_path, config)
     _note("raw", repo, _ref(repo, config), rel_path)
+    if config.archive:
+        ref = _ref(repo, config)
+        d = archive.snapshot_dir(_owner(repo, config), repo, ref, config)
+        return _dir_read_optional(d, rel_path)
+    url = _remote_url(repo, rel_path, config)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         return None
@@ -263,11 +272,15 @@ def list_tree(repo: str, rel_path: str, config, missing_ok: bool = False) -> lis
         return _dir_list_tree(d, rel_path, f"local {repo} ({d})", missing_ok)
     # Remote: GitHub git trees API — one request, recursive
     owner = _owner(repo, config)
+    _note("tree", repo, _ref(repo, config), rel_path)
+    if config.archive:
+        ref = _ref(repo, config)
+        d = archive.snapshot_dir(owner, repo, ref, config)
+        return _dir_list_tree(d, rel_path, f"{repo}@{ref} snapshot", missing_ok)
     url = (
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"git/trees/{_ref(repo, config)}?recursive=1"
     )
-    _note("tree", repo, _ref(repo, config), rel_path)
     r = _get("listing tree", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         if missing_ok:
@@ -289,11 +302,15 @@ def list_dir(repo: str, rel_path: str, config, dirs_only: bool = False) -> list[
             return _git_ls_tree(d, _ref(repo, config), rel_path, dirs_only)
         return _dir_list(d, rel_path, f"local {repo} ({d})", dirs_only)
     owner = _owner(repo, config)
+    _note("list", repo, _ref(repo, config), rel_path)
+    if config.archive:
+        ref = _ref(repo, config)
+        d = archive.snapshot_dir(owner, repo, ref, config)
+        return _dir_list(d, rel_path, f"{repo}@{ref} snapshot", dirs_only)
     url = (
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={_ref(repo, config)}"
     )
-    _note("list", repo, _ref(repo, config), rel_path)
     r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -318,11 +335,14 @@ def list_dir_at_ref(
     if where == "local" and _is_pinned(repo, config):
         return _git_ls_tree(d, ref, rel_path, dirs_only)
     owner = _owner(repo, config)
+    _note("list", repo, ref, rel_path)
+    if config.archive:
+        d = archive.snapshot_dir(owner, repo, ref, config)
+        return _dir_list(d, rel_path, f"{repo}@{ref} snapshot", dirs_only)
     url = (
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={ref}"
     )
-    _note("list", repo, ref, rel_path)
     r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
@@ -395,11 +415,18 @@ def read_at_ref(
     if where == "local" and _is_pinned(repo, config):
         return _git_show(d, ref, rel_path, optional=optional)
     owner = _owner(repo, config)
+    _note("raw", repo, ref, rel_path)
+    if config.archive:
+        d = archive.snapshot_dir(owner, repo, ref, config)
+        return (
+            _dir_read_optional(d, rel_path)
+            if optional
+            else _dir_read(d, rel_path, f"{repo}@{ref} snapshot")
+        )
     url = (
         f"{config.remote.github_raw}{owner}/{repo.replace('_', '-')}/"
         f"{ref}/{rel_path}"
     )
-    _note("raw", repo, ref, rel_path)
     r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         if optional:

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -97,6 +97,27 @@ def _http_error(action: str, url: str, r) -> SourceError:
     return SourceError(msg)
 
 
+_GH_JSON = {"Accept": "application/vnd.github.v3+json"}
+
+
+def _get(action: str, url: str, *, json_api: bool = False, ok=()):
+    """GET `url` with auth + a 30s timeout; return the Response.
+
+    `json_api` sends the GitHub REST Accept header. A transport failure, or a
+    non-ok status whose code is not in `ok`, raises SourceError (with a
+    rate-limit hint via _http_error); the caller keeps its own handling for the
+    codes it whitelists (e.g. a 404 that means "absent", not "failed").
+    """
+    extra = _GH_JSON if json_api else None
+    try:
+        r = requests.get(url, timeout=30, headers=_auth_headers(url, extra))
+    except requests.RequestException as e:
+        raise SourceError(f"network error {action} {url}: {e}") from e
+    if not r.ok and r.status_code not in ok:
+        raise _http_error(action, url, r)
+    return r
+
+
 def _source(repo: str, config):
     return config.sources.get(repo)
 
@@ -239,14 +260,9 @@ def read(repo: str, rel_path: str, config) -> bytes:
             raise SourceError(f"{rel_path} not found in local {repo} ({d})")
         return p.read_bytes()
     url = _remote_url(repo, rel_path, config)
-    try:
-        r = requests.get(url, timeout=30, headers=_auth_headers(url))
-    except requests.RequestException as e:
-        raise SourceError(f"network error fetching {url}: {e}") from e
+    r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
-    if not r.ok:
-        raise _http_error("fetching", url, r)
     return r.content
 
 
@@ -259,14 +275,9 @@ def read_optional(repo: str, rel_path: str, config) -> bytes | None:
         p = d / rel_path
         return p.read_bytes() if p.exists() else None
     url = _remote_url(repo, rel_path, config)
-    try:
-        r = requests.get(url, timeout=30, headers=_auth_headers(url))
-    except requests.RequestException as e:
-        raise SourceError(f"network error fetching {url}: {e}") from e
+    r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         return None
-    if not r.ok:
-        raise _http_error("fetching", url, r)
     return r.content
 
 
@@ -307,20 +318,11 @@ def list_tree(repo: str, rel_path: str, config, missing_ok: bool = False) -> lis
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"git/trees/{_ref(repo, config)}?recursive=1"
     )
-    try:
-        r = requests.get(
-            url,
-            timeout=30,
-            headers=_auth_headers(url, {"Accept": "application/vnd.github.v3+json"}),
-        )
-    except requests.RequestException as e:
-        raise SourceError(f"network error listing tree {url}: {e}") from e
+    r = _get("listing tree", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         if missing_ok:
             return []
         raise SourceError(f"404 not found: {url}")
-    if not r.ok:
-        raise _http_error("listing tree", url, r)
     prefix = rel_path.rstrip("/") + "/"
     return [
         item["path"]
@@ -344,18 +346,9 @@ def list_dir(repo: str, rel_path: str, config, dirs_only: bool = False) -> list[
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={_ref(repo, config)}"
     )
-    try:
-        r = requests.get(
-            url,
-            timeout=30,
-            headers=_auth_headers(url, {"Accept": "application/vnd.github.v3+json"}),
-        )
-    except requests.RequestException as e:
-        raise SourceError(f"network error listing {url}: {e}") from e
+    r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
-    if not r.ok:
-        raise _http_error("listing", url, r)
     items = r.json()
     if dirs_only:
         items = [it for it in items if it.get("type") == "dir"]
@@ -381,18 +374,9 @@ def list_dir_at_ref(
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"
         f"contents/{rel_path}?ref={ref}"
     )
-    try:
-        r = requests.get(
-            url,
-            timeout=30,
-            headers=_auth_headers(url, {"Accept": "application/vnd.github.v3+json"}),
-        )
-    except requests.RequestException as e:
-        raise SourceError(f"network error listing {url}: {e}") from e
+    r = _get("listing", url, json_api=True, ok=(404,))
     if r.status_code == 404:
         raise SourceError(f"404 not found: {url}")
-    if not r.ok:
-        raise _http_error("listing", url, r)
     items = r.json()
     if dirs_only:
         items = [it for it in items if it.get("type") == "dir"]
@@ -407,20 +391,11 @@ def ref_exists(repo: str, ref: str, config) -> bool:
         return _git_ref_exists(d, ref)
     owner = _owner(repo, config)
     url = f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/commits/{ref}"
-    try:
-        r = requests.get(
-            url,
-            timeout=30,
-            headers=_auth_headers(url, {"Accept": "application/vnd.github.v3+json"}),
-        )
-    except requests.RequestException as e:
-        raise SourceError(f"network error checking ref {url}: {e}") from e
+    r = _get("checking ref", url, json_api=True, ok=(404, 422))
     # GitHub's commits API returns 422 (not 404) for a ref that does not
     # resolve; treat both as "absent" so the resolver probes the next candidate.
     if r.status_code in (404, 422):
         return False
-    if not r.ok:
-        raise _http_error("checking ref", url, r)
     return True
 
 
@@ -474,16 +449,11 @@ def read_at_ref(
         f"{config.remote.github_raw}{owner}/{repo.replace('_', '-')}/"
         f"{ref}/{rel_path}"
     )
-    try:
-        r = requests.get(url, timeout=30, headers=_auth_headers(url))
-    except requests.RequestException as e:
-        raise SourceError(f"network error fetching {url}: {e}") from e
+    r = _get("fetching", url, ok=(404,))
     if r.status_code == 404:
         if optional:
             return None
         raise SourceError(f"404 not found: {url}")
-    if not r.ok:
-        raise _http_error("fetching", url, r)
     return r.content
 
 

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -46,6 +46,34 @@ def _note(kind: str, repo: str, ref: str, detail: str = "") -> None:
     _progress(f"  [{_calls:>3}] {kind:<5} {loc} @ {ref}")
 
 
+def _dir_read(d, rel_path, where):
+    p = d / rel_path
+    if not p.exists():
+        raise SourceError(f"{rel_path} not found in {where}")
+    return p.read_bytes()
+
+
+def _dir_read_optional(d, rel_path):
+    p = d / rel_path
+    return p.read_bytes() if p.exists() else None
+
+
+def _dir_list_tree(d, rel_path, where, missing_ok=False):
+    p = d / rel_path
+    if not p.is_dir():
+        if missing_ok:
+            return []
+        raise SourceError(f"{rel_path} not a directory in {where}")
+    return sorted(str(f.relative_to(d)) for f in p.rglob("*") if f.is_file())
+
+
+def _dir_list(d, rel_path, where, dirs_only=False):
+    p = d / rel_path
+    if not p.is_dir():
+        raise SourceError(f"{rel_path} not a directory in {where}")
+    return [x.name for x in p.iterdir() if (not dirs_only or x.is_dir())]
+
+
 def _source(repo: str, config):
     return config.sources.get(repo)
 
@@ -183,10 +211,7 @@ def read(repo: str, rel_path: str, config) -> bytes:
     if where == "local":
         if _is_pinned(repo, config):
             return _git_show(d, _ref(repo, config), rel_path)
-        p = d / rel_path
-        if not p.exists():
-            raise SourceError(f"{rel_path} not found in local {repo} ({d})")
-        return p.read_bytes()
+        return _dir_read(d, rel_path, f"local {repo} ({d})")
     url = _remote_url(repo, rel_path, config)
     _note("raw", repo, _ref(repo, config), rel_path)
     r = _get("fetching", url, ok=(404,))
@@ -201,8 +226,7 @@ def read_optional(repo: str, rel_path: str, config) -> bytes | None:
     if where == "local":
         if _is_pinned(repo, config):
             return _git_show(d, _ref(repo, config), rel_path, optional=True)
-        p = d / rel_path
-        return p.read_bytes() if p.exists() else None
+        return _dir_read_optional(d, rel_path)
     url = _remote_url(repo, rel_path, config)
     _note("raw", repo, _ref(repo, config), rel_path)
     r = _get("fetching", url, ok=(404,))
@@ -236,12 +260,7 @@ def list_tree(repo: str, rel_path: str, config, missing_ok: bool = False) -> lis
                 _meta, _, path = line.partition("\t")
                 out.append(path)
             return out
-        p = d / rel_path
-        if not p.is_dir():
-            if missing_ok:
-                return []
-            raise SourceError(f"{rel_path} not a directory in local {repo} ({d})")
-        return sorted(str(f.relative_to(d)) for f in p.rglob("*") if f.is_file())
+        return _dir_list_tree(d, rel_path, f"local {repo} ({d})", missing_ok)
     # Remote: GitHub git trees API — one request, recursive
     owner = _owner(repo, config)
     url = (
@@ -268,10 +287,7 @@ def list_dir(repo: str, rel_path: str, config, dirs_only: bool = False) -> list[
     if where == "local":
         if _is_pinned(repo, config):
             return _git_ls_tree(d, _ref(repo, config), rel_path, dirs_only)
-        p = d / rel_path
-        if not p.is_dir():
-            raise SourceError(f"{rel_path} not a directory in local {repo} ({d})")
-        return [x.name for x in p.iterdir() if (not dirs_only or x.is_dir())]
+        return _dir_list(d, rel_path, f"local {repo} ({d})", dirs_only)
     owner = _owner(repo, config)
     url = (
         f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/"

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -5,18 +5,20 @@ A set `branch` *pins* the repo: it is always read remotely at that ref, so the
 result is deterministic regardless of any local checkout's current branch.
 """
 
-import datetime
-import os
 import subprocess
 from pathlib import Path
-from urllib.parse import urlparse
 
-import requests
+from osism_drift.http import SourceError, _get
 
-
-class SourceError(Exception):
-    """Raised on any read/list failure that should abort the run."""
-
+# Re-exported so callers/tests reach the transport layer via osism_drift.source
+# unchanged after the http.py split.
+from osism_drift.http import (  # noqa: F401
+    _auth_headers,
+    _rate_limit_hint,
+    _http_error,
+    _GITHUB_HOSTS,
+    _GH_JSON,
+)
 
 # Progress sink for remote reads. A remote drift run makes dozens of GitHub
 # requests over minutes with no other output, which reads as "hung" and invites
@@ -42,124 +44,6 @@ def _note(kind: str, repo: str, ref: str, detail: str = "") -> None:
         return
     loc = f"{repo}:{detail}" if detail else repo
     _progress(f"  [{_calls:>3}] {kind:<5} {loc} @ {ref}")
-
-
-# Hosts the GitHub bearer token may be sent to. github_raw/github_api are
-# configurable (a mirror, proxy, or test server), so the token is attached only
-# when the actual request host is public GitHub -- an ambient GITHUB_TOKEN must
-# never leak to a non-GitHub endpoint someone pointed the base URLs at.
-_GITHUB_HOSTS = frozenset({"github.com", "api.github.com", "raw.githubusercontent.com"})
-
-
-def _auth_headers(url: str, extra: dict | None = None) -> dict:
-    """Merge a GitHub bearer token into request headers when one is available
-    AND `url` targets a public GitHub host.
-
-    Reads GITHUB_TOKEN (then GH_TOKEN) from the environment. When set and the
-    request goes to a GitHub host, the read is authenticated, lifting GitHub's
-    unauthenticated 60/hr per-IP limit to 5000/hr; otherwise behaviour is
-    unchanged (unauthenticated). Gating on the host keeps a token configured for
-    github.com from leaking to a non-GitHub github_raw/github_api override. The
-    Zuul periodic-daily job carries no token today, so this is a no-op there and
-    a win for local/developer and any future authenticated runs.
-    """
-    headers = dict(extra or {})
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if token and (urlparse(url).hostname or "") in _GITHUB_HOSTS:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
-def _rate_limit_hint(r) -> str | None:
-    """A helpful hint when response `r` is a GitHub rate-limit rejection, else None.
-
-    GitHub reports its primary rate limit as HTTP 403 (or, more recently, 429)
-    with X-RateLimit-Remaining: 0, and secondary limits as 403/429 with a
-    Retry-After header. Unauthenticated requests share a low per-IP hourly
-    budget that a full remote drift run can exhaust; a token lifts it (see
-    _auth_headers), so the actionable advice differs by auth state. The exact
-    quotas are not hardcoded here (GitHub changes them, and this string is read
-    whenever the script runs, not when it was written): the actual limit in
-    effect is echoed from the response's X-RateLimit-Limit header. A 403 without
-    those markers is some other refusal (auth/permission), not throttling, and
-    gets no hint.
-
-    Separately, raw.githubusercontent.com (a Fastly CDN serving file bytes, the
-    bulk of a remote run) throttles per-IP and returns 429 with none of those
-    headers; that markerless 429 gets its own hint pointing at --base-dir, since
-    a token does not draw the raw host from the API budget.
-    """
-    if r.status_code not in (403, 429):
-        return None
-    retry_after = r.headers.get("Retry-After")
-    if r.headers.get("X-RateLimit-Remaining") != "0" and retry_after is None:
-        # No GitHub-API rate-limit markers. raw.githubusercontent.com is a Fastly
-        # CDN that throttles per-IP and returns 429 with none of these headers, so
-        # a markerless 429 is CDN throttling (the API path always carries a marker)
-        # and still deserves an actionable hint. A markerless 403, by contrast, is
-        # an ordinary auth/permission refusal, not throttling, and gets none.
-        if r.status_code == 429:
-            return (
-                "raw.githubusercontent.com throttled this request. Its rate limit "
-                "is per-IP, intermittent, and separate from the GitHub API budget "
-                "(a token may raise the anonymous tier but won't guarantee relief). "
-                "Prefer local checkouts (--base-dir) to avoid remote fetches, retry "
-                "later, or run from a different network."
-            )
-        return None
-    parts = ["GitHub API rate limit hit."]
-    limit = r.headers.get("X-RateLimit-Limit")
-    quota = f" (limit in effect: {limit}/hr)" if limit and limit.isdigit() else ""
-    reset = r.headers.get("X-RateLimit-Reset")
-    if retry_after and retry_after.isdigit():
-        parts.append(f"Retry after {retry_after}s.")
-    elif reset and reset.isdigit():
-        when = datetime.datetime.fromtimestamp(
-            int(reset), datetime.timezone.utc
-        ).strftime("%Y-%m-%d %H:%M UTC")
-        parts.append(f"Limit resets at {when}.")
-    if os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"):
-        parts.append(
-            f"This run is authenticated{quota}; wait for the reset or reduce "
-            "concurrency."
-        )
-    else:
-        parts.append(
-            f"This run is unauthenticated{quota}; set GITHUB_TOKEN (or GH_TOKEN) "
-            "to use the much higher authenticated limit."
-        )
-    return " ".join(parts)
-
-
-def _http_error(action: str, url: str, r) -> SourceError:
-    """SourceError for a non-ok HTTP response, with a rate-limit hint appended
-    when the response looks like GitHub throttling rather than a plain failure."""
-    msg = f"HTTP {r.status_code} {action} {url}"
-    hint = _rate_limit_hint(r)
-    if hint:
-        msg = f"{msg} — {hint}"
-    return SourceError(msg)
-
-
-_GH_JSON = {"Accept": "application/vnd.github.v3+json"}
-
-
-def _get(action: str, url: str, *, json_api: bool = False, ok=()):
-    """GET `url` with auth + a 30s timeout; return the Response.
-
-    `json_api` sends the GitHub REST Accept header. A transport failure, or a
-    non-ok status whose code is not in `ok`, raises SourceError (with a
-    rate-limit hint via _http_error); the caller keeps its own handling for the
-    codes it whitelists (e.g. a 404 that means "absent", not "failed").
-    """
-    extra = _GH_JSON if json_api else None
-    try:
-        r = requests.get(url, timeout=30, headers=_auth_headers(url, extra))
-    except requests.RequestException as e:
-        raise SourceError(f"network error {action} {url}: {e}") from e
-    if not r.ok and r.status_code not in ok:
-        raise _http_error(action, url, r)
-    return r
 
 
 def _source(repo: str, config):

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -83,11 +83,29 @@ def _rate_limit_hint(r) -> str | None:
     effect is echoed from the response's X-RateLimit-Limit header. A 403 without
     those markers is some other refusal (auth/permission), not throttling, and
     gets no hint.
+
+    Separately, raw.githubusercontent.com (a Fastly CDN serving file bytes, the
+    bulk of a remote run) throttles per-IP and returns 429 with none of those
+    headers; that markerless 429 gets its own hint pointing at --base-dir, since
+    a token does not draw the raw host from the API budget.
     """
     if r.status_code not in (403, 429):
         return None
     retry_after = r.headers.get("Retry-After")
     if r.headers.get("X-RateLimit-Remaining") != "0" and retry_after is None:
+        # No GitHub-API rate-limit markers. raw.githubusercontent.com is a Fastly
+        # CDN that throttles per-IP and returns 429 with none of these headers, so
+        # a markerless 429 is CDN throttling (the API path always carries a marker)
+        # and still deserves an actionable hint. A markerless 403, by contrast, is
+        # an ordinary auth/permission refusal, not throttling, and gets none.
+        if r.status_code == 429:
+            return (
+                "raw.githubusercontent.com throttled this request. Its rate limit "
+                "is per-IP, intermittent, and separate from the GitHub API budget "
+                "(a token may raise the anonymous tier but won't guarantee relief). "
+                "Prefer local checkouts (--base-dir) to avoid remote fetches, retry "
+                "later, or run from a different network."
+            )
         return None
     parts = ["GitHub API rate limit hit."]
     limit = r.headers.get("X-RateLimit-Limit")

--- a/tests/kolla_drift/test_archive.py
+++ b/tests/kolla_drift/test_archive.py
@@ -1,0 +1,135 @@
+import io
+import tarfile
+import types
+
+import pytest
+import responses
+
+from osism_drift import archive
+from osism_drift.http import SourceError
+
+
+def _targz(files, *, top="osism-release-abc123", extra_members=None):
+    """files: {relpath: bytes} placed under a single top-level dir."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for rel, data in files.items():
+            info = tarfile.TarInfo(f"{top}/{rel}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        for m in extra_members or []:
+            tar.addfile(m, io.BytesIO(b""))
+    return buf.getvalue()
+
+
+def _stub():
+    return types.SimpleNamespace(
+        remote=types.SimpleNamespace(github_api="https://api.github.com/repos/"),
+        snapshot_cache={},
+    )
+
+
+def test_repo_slug_and_archive_url():
+    assert (
+        archive._repo_slug("ansible_collection_services")
+        == "ansible-collection-services"
+    )
+    assert (
+        archive._archive_url(
+            "https://api.github.com/repos/", "osism", "kolla_ansible", "stable/2025.2"
+        )
+        == "https://api.github.com/repos/osism/kolla-ansible/tarball/stable/2025.2"
+    )
+
+
+@responses.activate
+def test_snapshot_dir_fetches_extracts_and_serves():
+    cfg = _stub()
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/kolla-ansible/tarball/main",
+        body=_targz({"etc/x.yml": b"hi\n"}),
+        status=200,
+    )
+    d = archive.snapshot_dir("osism", "kolla_ansible", "main", cfg)
+    assert (d / "etc/x.yml").read_bytes() == b"hi\n"
+
+
+@responses.activate
+def test_snapshot_dir_memoizes_one_http_call():
+    cfg = _stub()
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/r/tarball/main",
+        body=_targz({"f": b"z"}),
+        status=200,
+    )
+    archive.snapshot_dir("osism", "r", "main", cfg)
+    archive.snapshot_dir("osism", "r", "main", cfg)
+    assert len(responses.calls) == 1  # second call served from snapshot_cache
+
+
+@responses.activate
+def test_snapshot_dir_404_raises():
+    cfg = _stub()
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/r/tarball/nope",
+        status=404,
+    )
+    with pytest.raises(SourceError, match="no archive for r@nope"):
+        archive.snapshot_dir("osism", "r", "nope", cfg)
+
+
+@responses.activate
+def test_fetch_retries_once_then_succeeds():
+    cfg = _stub()
+    url = "https://api.github.com/repos/osism/r/tarball/main"
+    responses.add(responses.GET, url, status=500)  # first attempt fails
+    responses.add(responses.GET, url, body=_targz({"f": b"z"}), status=200)
+    d = archive.snapshot_dir("osism", "r", "main", cfg)
+    assert (d / "f").read_bytes() == b"z"
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_fetch_fails_twice_raises():
+    cfg = _stub()
+    url = "https://api.github.com/repos/osism/r/tarball/main"
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, status=500)
+    with pytest.raises(SourceError):
+        archive.snapshot_dir("osism", "r", "main", cfg)
+
+
+@responses.activate
+def test_unsafe_traversal_member_rejected():
+    cfg = _stub()
+    bad = tarfile.TarInfo("../evil")  # escapes the extraction dir (resolves above it)
+    bad.size = 0
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/r/tarball/main",
+        body=_targz({"ok": b"x"}, extra_members=[bad]),
+        status=200,
+    )
+    with pytest.raises(SourceError):
+        archive.snapshot_dir("osism", "r", "main", cfg)
+
+
+@responses.activate
+def test_symlink_member_rejected_on_fallback(monkeypatch):
+    # Force the no-data_filter fallback path and confirm it rejects a link member.
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
+    cfg = _stub()
+    link = tarfile.TarInfo("osism-r-abc/link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "/etc/passwd"
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/r/tarball/main",
+        body=_targz({"ok": b"x"}, extra_members=[link]),
+        status=200,
+    )
+    with pytest.raises(SourceError):
+        archive.snapshot_dir("osism", "r", "main", cfg)

--- a/tests/kolla_drift/test_config.py
+++ b/tests/kolla_drift/test_config.py
@@ -357,3 +357,22 @@ plugins: {}
     )
     assert cfg.releases == ()
     assert cfg.release_refs == {}
+
+
+def test_archive_and_snapshot_cache_defaults(tmp_path):
+    import dataclasses
+
+    cfg = load_config(
+        _write_cfg(
+            tmp_path,
+            """
+remote: {github_raw: "https://raw/", github_api: "https://api/", branch: main}
+release_version: latest
+plugins: {}
+""",
+        )
+    )
+    assert cfg.archive is False
+    assert cfg.snapshot_cache == {}
+    replaced = dataclasses.replace(cfg, archive=True)
+    assert replaced.archive is True

--- a/tests/kolla_drift/test_dir_helpers.py
+++ b/tests/kolla_drift/test_dir_helpers.py
@@ -1,0 +1,61 @@
+import pytest
+from osism_drift import source
+from osism_drift.http import SourceError
+
+
+def test_dir_read_returns_bytes(tmp_path):
+    (tmp_path / "x").write_bytes(b"hello")
+    assert source._dir_read(tmp_path, "x", "ctx") == b"hello"
+
+
+def test_dir_read_missing_raises_with_where(tmp_path):
+    with pytest.raises(SourceError, match="ctx"):
+        source._dir_read(tmp_path, "missing", "ctx")
+
+
+def test_dir_read_optional_present(tmp_path):
+    (tmp_path / "x").write_bytes(b"data")
+    assert source._dir_read_optional(tmp_path, "x") == b"data"
+
+
+def test_dir_read_optional_absent_returns_none(tmp_path):
+    assert source._dir_read_optional(tmp_path, "absent") is None
+
+
+def test_dir_list_tree_sorted_repo_relative(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "b.yml").write_bytes(b"")
+    (tmp_path / "a" / "c").mkdir()
+    (tmp_path / "a" / "c" / "d.yml").write_bytes(b"")
+    result = source._dir_list_tree(tmp_path, "a", "ctx")
+    assert result == ["a/b.yml", "a/c/d.yml"]
+
+
+def test_dir_list_tree_missing_raises(tmp_path):
+    with pytest.raises(SourceError, match="ctx"):
+        source._dir_list_tree(tmp_path, "nope", "ctx")
+
+
+def test_dir_list_tree_missing_ok_returns_empty(tmp_path):
+    assert source._dir_list_tree(tmp_path, "nope", "ctx", missing_ok=True) == []
+
+
+def test_dir_list_returns_names(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "sub").mkdir()
+    (tmp_path / "a" / "file.txt").write_bytes(b"")
+    result = source._dir_list(tmp_path, "a", "ctx")
+    assert set(result) == {"sub", "file.txt"}
+
+
+def test_dir_list_dirs_only(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "sub").mkdir()
+    (tmp_path / "a" / "file.txt").write_bytes(b"")
+    result = source._dir_list(tmp_path, "a", "ctx", dirs_only=True)
+    assert result == ["sub"]
+
+
+def test_dir_list_missing_raises(tmp_path):
+    with pytest.raises(SourceError, match="ctx"):
+        source._dir_list(tmp_path, "nope", "ctx")

--- a/tests/kolla_drift/test_source.py
+++ b/tests/kolla_drift/test_source.py
@@ -1,11 +1,26 @@
 import dataclasses
+import io
 import subprocess as _sub
+import tarfile
 
 import pytest
 import requests
 import responses
 from osism_drift.source import read, SourceError, read_optional, list_dir
 from osism_drift.config import load_config, SourceCfg
+
+
+def _targz(files, *, top="osism-release-abc123", extra_members=None):
+    """files: {relpath: bytes} placed under a single top-level dir."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for rel, data in files.items():
+            info = tarfile.TarInfo(f"{top}/{rel}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        for m in extra_members or []:
+            tar.addfile(m, io.BytesIO(b""))
+    return buf.getvalue()
 
 
 def _cfg(tmp_path, base_dirs=(), remote_fallback=False):
@@ -1025,3 +1040,100 @@ def test_get_does_not_send_auth_to_non_github_mirror(monkeypatch):
     )
     source.read("release", "x.yml", cfg)
     assert "Authorization" not in responses.calls[0].request.headers
+
+
+@responses.activate
+def test_read_uses_archive_when_enabled(tmp_path):
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/main",
+        body=_targz({"latest/base.yml": b"payload\n"}, top="osism-release-abc"),
+        status=200,
+    )
+    assert read("release", "latest/base.yml", cfg) == b"payload\n"
+
+
+@responses.activate
+def test_archive_snapshot_shared_across_reads(tmp_path):
+    # Two reads from the same (repo, ref) trigger exactly one tarball fetch.
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/main",
+        body=_targz({"a.yml": b"1", "b.yml": b"2"}, top="osism-release-abc"),
+        status=200,
+    )
+    assert read("release", "a.yml", cfg) == b"1"
+    assert read("release", "b.yml", cfg) == b"2"
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_list_dir_uses_archive(tmp_path):
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/main",
+        body=_targz(
+            {"conf/a.yml": b"1", "conf/sub/b.yml": b"2", "conf/d/keep": b""},
+            top="osism-release-x",
+        ),
+        status=200,
+    )
+    assert sorted(list_dir("release", "conf", cfg)) == ["a.yml", "d", "sub"]
+    assert sorted(list_dir("release", "conf", cfg, dirs_only=True)) == ["d", "sub"]
+
+
+@responses.activate
+def test_list_tree_uses_archive(tmp_path):
+    from osism_drift.source import list_tree
+
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/main",
+        body=_targz(
+            {"conf/a.yml": b"1", "conf/sub/b.yml": b"2"}, top="osism-release-x"
+        ),
+        status=200,
+    )
+    # repo-relative paths of files only (dirs excluded), sorted.
+    assert list_tree("release", "conf", cfg) == ["conf/a.yml", "conf/sub/b.yml"]
+
+
+@responses.activate
+def test_list_dir_at_ref_uses_archive(tmp_path):
+    from osism_drift.source import list_dir_at_ref
+
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/stable/2025.2",
+        body=_targz({"d/x.yml": b"1", "d/y.yml": b"2"}, top="osism-release-x"),
+        status=200,
+    )
+    assert sorted(list_dir_at_ref("release", "d", "stable/2025.2", cfg)) == [
+        "x.yml",
+        "y.yml",
+    ]
+
+
+@responses.activate
+def test_read_at_ref_uses_archive(tmp_path):
+    from osism_drift.source import read_at_ref
+
+    cfg = dataclasses.replace(_cfg(tmp_path), archive=True)
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/osism/release/tarball/stable/2025.2",
+        body=_targz({"latest/base.yml": b"v"}, top="osism-release-x"),
+        status=200,
+    )
+    assert read_at_ref("release", "latest/base.yml", "stable/2025.2", cfg) == b"v"
+    # A missing file with optional=True returns None, served from the same
+    # memoized snapshot (no second fetch).
+    assert (
+        read_at_ref("release", "nope.yml", "stable/2025.2", cfg, optional=True) is None
+    )
+    assert len(responses.calls) == 1

--- a/tests/kolla_drift/test_source.py
+++ b/tests/kolla_drift/test_source.py
@@ -909,6 +909,29 @@ def test_secondary_rate_limit_retry_after_gives_hint(tmp_path, monkeypatch):
 
 
 @responses.activate
+def test_raw_cdn_429_without_headers_gives_raw_specific_hint(tmp_path, monkeypatch):
+    # raw.githubusercontent.com is a Fastly CDN that throttles per-IP and returns
+    # 429 with NONE of the X-RateLimit-*/Retry-After headers the API sends. That
+    # markerless 429 must still yield an actionable hint, distinct from the
+    # api.github.com rate-limit message (which the reset/quota text is for).
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/osism/release/main/latest/base.yml",
+        status=429,
+    )
+    cfg = _cfg(tmp_path)
+    with pytest.raises(SourceError) as exc:
+        read("release", "latest/base.yml", cfg)
+    msg = str(exc.value)
+    assert "HTTP 429" in msg
+    assert "--base-dir" in msg  # the actionable advice for the raw CDN
+    assert "per-IP" in msg
+    assert "GitHub API rate limit hit" not in msg  # not the API-quota message
+
+
+@responses.activate
 def test_plain_403_is_not_mistaken_for_rate_limiting(tmp_path):
     # A 403 without any rate-limit marker (e.g. a permission refusal) must stay a
     # plain HTTP error with no misleading rate-limit hint.

--- a/tests/test_driver_groups.py
+++ b/tests/test_driver_groups.py
@@ -99,6 +99,22 @@ def test_group_all_runs_both_groups(tmp_path, capsys):
     assert "fake_kolla" in out
 
 
+def test_archive_mode_preamble_not_misleading(tmp_path, capsys):
+    # Default (archive) remote run: the heads-up must not claim slow per-file API
+    # reads -- archive mode makes a handful of tarball fetches, not dozens.
+    assert _run(tmp_path, "--group", "all") == 1
+    err = capsys.readouterr().err
+    assert "several minutes" not in err
+    assert "archive" in err.lower()
+
+
+def test_use_raw_get_preamble_warns_slow(tmp_path, capsys):
+    # --use-raw-get restores the per-file API path, where the slow warning is apt.
+    assert _run(tmp_path, "--group", "all", "--use-raw-get") == 1
+    err = capsys.readouterr().err
+    assert "several minutes" in err
+
+
 def test_missing_group_errors(tmp_path):
     # --group is required: argparse aborts with exit 2 (no run).
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## What

Speeds up and stabilizes remote drift runs by fetching each repo once as a
tarball instead of per-file over the GitHub API, plus the transport-layer refactor
it builds on.

**Archive backend**
- `archive.py` — fetches a `(repo, ref)` tarball once, memoizes it, and serves all
  reads/listings from the extracted tree. On by default; `--use-raw-get` selects the
  old per-file raw-GET path.
- Turns a full remote run from ~thousands of GitHub requests into one tarball per
  repo — far less rate-limit exposure.

**Transport refactor it builds on**
- `_get` — one shared helper for the repeated GitHub-request skeleton (auth, timeout,
  error wrapping, rate-limit hint).
- `http.py` — the transport/error layer extracted out of `source.py`.
- Progress output during remote reads; a CDN-429 hint for `raw.githubusercontent.com`;
  shared dir-tree helpers for local branches.

Behavior-preserving for existing checks; 303 tests pass.

## Merge order

This PR carries the shared transport layer (`_get`, `http.py`, progress) that the
drift-tooling PR also currently contains. **Merge this before drift-tooling**; that PR
is then rebased to drop the two now-shared commits.

## Related

- osism/release#2569 — drift-tooling (shares the transport layer; rebased after this lands)
