### PR TITLE
kolla: reconcile the drift-check allowlist

### DIFF
--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -61,9 +61,16 @@ allow:
   - {plugin: kolla_inventory, image: collectd, match: prefix, reason: "not deployed in this series"}
   # --- kolla_enablement_orphan ---
   # OSISM-invented enable flags with no upstream counterpart by design (not a
-  # removed-upstream service). Truthy, so they surface in the truthy-only scope.
+  # removed-upstream service). The check uses explicit scope -- it flags every
+  # invented enable_* by name regardless of value -- so these surface even when off.
   - {plugin: kolla_enablement_orphan, image: common, reason: "OSISM-invented flag; no upstream counterpart by design"}
   - {plugin: kolla_enablement_orphan, image: kolla_operations, reason: "OSISM-invented flag; no upstream counterpart by design"}
+  # Live OSISM services whose flag/var names collide with dead or renamed kolla
+  # ones. Verified via upstream git history + OSISM consumers: not the removed
+  # kolla service, so allowlisting here also clears their <svc>_* companion vars
+  # in kolla_orphan_config (which derives its dead-service set from this check).
+  - {plugin: kolla_enablement_orphan, image: chrony, reason: "OSISM host-level NTP (ansible-collection-services/roles/chrony consumes chrony_servers/chrony_allowed_subnets); not the kolla chrony container removed upstream in Xena"}
+  - {plugin: kolla_enablement_orphan, image: openstack_exporter, reason: "OSISM k8s openstack-exporter (osism-kubernetes/roles/monitoring); OSISM invention, distinct from upstream prometheus_openstack_exporter"}
   # --- kolla_groupvars_missing ---
   # Upstream typo for neutron_external_interface (which OSISM defines correctly),
   # so it must not be mirrored. Waiting for the upstream fix to merge:

--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -77,12 +77,6 @@ allow:
   - {plugin: kolla_enablement_orphan, image: chrony, reason: "OSISM host-level NTP (ansible-collection-services/roles/chrony consumes chrony_servers/chrony_allowed_subnets); not the kolla chrony container removed upstream in Xena"}
   - {plugin: kolla_enablement_orphan, image: openstack_exporter, reason: "OSISM k8s openstack-exporter (osism-kubernetes/roles/monitoring); OSISM invention, distinct from upstream prometheus_openstack_exporter"}
   - {plugin: kolla_enablement_orphan, image: auditd, reason: "OSISM host-level auditd (ansible-collection-services/roles/auditd, gated by generic/auditd.yml + bootstrap/maintenance playbooks); never an upstream kolla service. enable_auditd is false by default, but explicit scope flags it by name regardless of value"}
-  # --- kolla_groupvars_missing ---
-  # Upstream typo for neutron_external_interface (which OSISM defines correctly),
-  # so it must not be mirrored. Waiting for the upstream fix to merge:
-  # https://review.opendev.org/c/openstack/kolla-ansible/+/985031
-  # Remove this entry once that lands (the check will then report it as stale).
-  - {plugin: kolla_groupvars_missing, image: eutron_external_interface, reason: "upstream typo for neutron_external_interface; awaiting upstream fix https://review.opendev.org/c/openstack/kolla-ansible/+/985031"}
   # --- kolla_image_orphan: OSISM-built / no upstream kolla-ansible role ---
   - {plugin: kolla_image_orphan, image: mariabackup_image, reason: "OSISM-built mariadb backup image; no upstream role"}
   - {plugin: kolla_image_orphan, image: mariabackup_tag, reason: "OSISM-built mariadb backup image; no upstream role"}

--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -29,6 +29,11 @@ allow:
   - plugin: role_unpinned
     image: zuul_log_server
     reason: "OSISM CI stack; version maintained in the zuul role, not release (osism/issues#1397)"
+  # Niche httpd role images intentionally kept as rolling tags (role-managed, not
+  # release-pinned): httpd serves static/proxy content; httpd_data is a one-shot
+  # rsync import sidecar (disabled by default) that tracks latest by design.
+  - {plugin: role_unpinned, image: httpd, reason: "OSISM httpd role (Apache static/proxy); role-managed rolling 'alpine' tag by design, not release-pinned"}
+  - {plugin: role_unpinned, image: httpd_data, reason: "one-shot rsync data-import sidecar (httpd_data_enable off by default); tracks registry.osism.tech/osism/rsync:latest by design"}
   # Not deployed in this OSISM series (cf. inventory IGNORE_NOT_DEPLOYED).
   - {plugin: kolla_version_chain_upstream, image: cyborg, reason: "not deployed in this series"}
   - {plugin: kolla_version_chain_upstream, image: tacker, reason: "not deployed in this series"}

--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -71,6 +71,7 @@ allow:
   # in kolla_orphan_config (which derives its dead-service set from this check).
   - {plugin: kolla_enablement_orphan, image: chrony, reason: "OSISM host-level NTP (ansible-collection-services/roles/chrony consumes chrony_servers/chrony_allowed_subnets); not the kolla chrony container removed upstream in Xena"}
   - {plugin: kolla_enablement_orphan, image: openstack_exporter, reason: "OSISM k8s openstack-exporter (osism-kubernetes/roles/monitoring); OSISM invention, distinct from upstream prometheus_openstack_exporter"}
+  - {plugin: kolla_enablement_orphan, image: auditd, reason: "OSISM host-level auditd (ansible-collection-services/roles/auditd, gated by generic/auditd.yml + bootstrap/maintenance playbooks); never an upstream kolla service. enable_auditd is false by default, but explicit scope flags it by name regardless of value"}
   # --- kolla_groupvars_missing ---
   # Upstream typo for neutron_external_interface (which OSISM defines correctly),
   # so it must not be mirrored. Waiting for the upstream fix to merge:

--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -80,3 +80,8 @@ allow:
   - {plugin: kolla_image_orphan, image: dcap_tag, reason: "OSISM DPU/dcap image; no upstream kolla image"}
   - {plugin: kolla_image_orphan, image: dcap_register_image_tag, reason: "OSISM DPU/dcap image; no upstream kolla image"}
   - {plugin: kolla_image_orphan, image: dcap_server_image_tag, reason: "OSISM DPU/dcap image; no upstream kolla image"}
+  # Defined in kolla-ansible master (neutron role) but not yet in a supported
+  # release; remove these once 2026.1 is supported (the union will cover them and
+  # the check will report the entries as stale).
+  - {plugin: kolla_image_orphan, image: neutron_ovn_vpn_agent_image, reason: "defined upstream at master, ahead of the supported release range"}
+  - {plugin: kolla_image_orphan, image: neutron_ovn_vpn_agent_tag, reason: "defined upstream at master, ahead of the supported release range"}


### PR DESCRIPTION
## What

Reconciles the kolla drift-check allowlist now that the checks (osism/release#2569,
merged) run against the current repos. Five commits, `src/drift-allowlist.yml` only:

- `neutron_ovn_vpn_agent` — defined upstream at master, ahead of the supported release
  range (self-retires once 2026.1 is supported).
- `chrony` / `openstack_exporter` — live OSISM inventions whose names collide with dead or
  renamed kolla services (verified via upstream git history + OSISM consumers); allowlisting
  at the enable-flag level also clears their companion vars in `kolla_orphan_config`.
- `auditd` — live OSISM host-level auditd; never an upstream kolla service.
- `httpd` rolling image tags — role-managed by design, not release-pinned.
- **Drop the stale `kolla_groupvars_missing` section** (`eutron_external_interface`):
  upstream fixed the typo on stable/2025.2 (bug 2160035, merged 2026-07-08), so the
  finding this entry suppressed is gone and the daily check reports the entry as stale —
  the removal trigger the entry's own comment named.

No merge-order constraint: the previous gate on osism/defaults#297 dissolved with the
upstream typo fix (the entry is stale on `main` today regardless of #297).

Builds on merged osism/release#2569 (drift checks) + #2570 (transport/archive backend).

## Related

- osism/release#2569 — the drift checks (merged)
- osism/defaults#297 — companion re-sync (no longer gates this PR)
