### PR TITLE
Remove three orphaned manager image definitions

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -10,7 +10,6 @@ osism: osism/osism
 osism_ansible: osism/osism-ansible
 osism_frontend: osism/osism-frontend
 osism_kubernetes: osism/osism-kubernetes
-osism_netbox: osism/osism-netbox
 redis: library/redis
 vault: hashicorp/vault
 sonic_vs: osism/sonic-vs
@@ -18,8 +17,6 @@ sonic_vs: osism/sonic-vs
 # mirror
 
 nexus: osism/nexus
-nginx: library/nginx
-registry: library/registry
 
 # ceph
 

--- a/latest/base.yml
+++ b/latest/base.yml
@@ -56,8 +56,6 @@ docker_images:
   netbox: 'v4.3.5'
   # renovate: datasource=docker depName=registry.osism.tech/osism/nexus
   nexus: '3.93.1'
-  # renovate: datasource=docker depName=nginx
-  nginx: '1.29.3-alpine'
   # renovate: datasource=docker depName=registry.osism.tech/osism/osism
   osism: '0.20260615.0'
   # renovate: datasource=docker depName=registry.osism.tech/osism/osism-ansible
@@ -76,8 +74,6 @@ docker_images:
   postgres: '16.11-alpine'
   # renovate: datasource=docker depName=redis
   redis: '7.4.7-alpine'
-  # renovate: datasource=docker depName=registry
-  registry: '3.0'
   # renovate: datasource=docker depName=hubblo/scaphandre
   scaphandre: '1.0.2'
   # renovate: datasource=docker depName=ubuntu/squid


### PR DESCRIPTION
Part of the `osism/issues#1405` cleanup — remove three manager image
definitions that the render emits but nothing deploys (flagged by the
drift detector's `image_orphan` check: `nginx`, `registry`, `osism_netbox`).

This is the **release** side:
- `latest/base.yml` — drop the `nginx` and `registry` `docker_images` pins.
- `etc/images.yml` — drop the `osism_netbox`, `nginx`, `registry` registry-path entries.

`netbox` (a distinct, consumed image) is left untouched. The matching
render-template emits are removed in the two companion PRs (generics +
container-image-osism-ansible).

Verified: `image_orphan` drops from 3 to 0.

Part of osism/issues#1405.