### PR TITLE
role_scan: credit container-template stream pins

### DIFF
--- a/src/osism_drift/drift/role_unpinned.py
+++ b/src/osism_drift/drift/role_unpinned.py
@@ -13,6 +13,7 @@ INPUT_FILES = [
     ("release", "<release_version>/base.yml"),
     ("generics", "environments/manager/images.yml"),
     ("ansible_collection_services", "roles/*/defaults/main.yml"),
+    ("container_image_osism_ansible", "files/src/templates/images.yml.j2"),
 ]
 SUMMARY = "{n} <alias>_tag pins in role defaults with no release base.yml pin:"
 REMEDIATION = (

--- a/src/osism_drift/role_scan.py
+++ b/src/osism_drift/role_scan.py
@@ -13,6 +13,8 @@ from osism_drift import manager_template, role_defaults, source
 
 _ROLES_REPO = "ansible_collection_services"
 _IMAGES = "environments/manager/images.yml"
+_OVERRIDE_REPO = "container_image_osism_ansible"
+_OVERRIDE_TEMPLATE = "files/src/templates/images.yml.j2"
 
 
 @dataclass(frozen=True)
@@ -32,6 +34,12 @@ def iter_role_pins(config):
     template_bytes = source.read("generics", _IMAGES, config)
     alias_map = manager_template.extract_alias_map(template_bytes)
     stream_resolved = manager_template.extract_stream_resolved(template_bytes)
+    # The generics manager template omits some aliases (e.g. cephclient,
+    # openstackclient) that the authoritative container render template pins to a
+    # <name>_version release-stream variable. Credit that template too, so those
+    # aliases are recognised as stream-resolved rather than role-pinned.
+    override_bytes = source.read(_OVERRIDE_REPO, _OVERRIDE_TEMPLATE, config)
+    stream_resolved |= manager_template.extract_stream_resolved(override_bytes)
     role_names = source.list_dir(_ROLES_REPO, "roles", config, dirs_only=True)
 
     for role in sorted(role_names):

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/trainclient/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/trainclient/defaults/main.yml
@@ -1,0 +1,1 @@
+trainclient_tag: 'rolling'

--- a/tests/image_drift/fixtures/container-image-osism-ansible/files/src/templates/images.yml.j2
+++ b/tests/image_drift/fixtures/container-image-osism-ansible/files/src/templates/images.yml.j2
@@ -9,3 +9,7 @@ ara_server_mariadb_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['mari
 
 manager_redis_tag: "{{ versions['redis'] }}"
 manager_redis_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['redis'] }}:{{ '{{' }} manager_redis_tag {{ '}}' }}"
+
+# stream-resolved only in this container template, not the generics manager images.yml
+trainclient_tag: "{{ '{{' }} trainclient_version|default(train_version) {{ '}}' }}"
+trainclient_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['trainclient'] }}:{{ '{{' }} trainclient_tag {{ '}}' }}"

--- a/tests/image_drift/test_role_unpinned.py
+++ b/tests/image_drift/test_role_unpinned.py
@@ -54,6 +54,22 @@ def test_stream_resolved_not_emitted(cfg):
     assert "ceph_ansible" not in drifts
 
 
+def test_input_files_declare_container_template():
+    """iter_role_pins reads the container override template to credit its
+    stream-resolved aliases, so the plugin must declare that repo or the driver
+    won't resolve it when role_unpinned runs alone in remote mode."""
+    repos = {repo for repo, _ in role_unpinned.INPUT_FILES}
+    assert "container_image_osism_ansible" in repos
+
+
+def test_container_stream_resolved_not_emitted(cfg):
+    """trainclient is stream-resolved only in the container images.yml.j2 (not the
+    generics manager template) — its <name>_version|default anchor still means the
+    release train governs, so a role-default pin must not surface as unpinned."""
+    drifts = _by_alias(role_unpinned.run(cfg, Allowlist(())))
+    assert "trainclient" not in drifts
+
+
 def test_allowlist_marks_ciinternal_allowlisted(cfg):
     al = Allowlist(
         (


### PR DESCRIPTION
## Problem

`role_unpinned` reports `cephclient` (`reef`) and `openstackclient`
(`2024.2`) as actionable drift — role-default `<alias>_tag` pins with no
canonical release pin. These are **false positives**.

Both tags are stream-wired in the authoritative *container* render
template (`container-image-osism-ansible/.../images.yml.j2`):

```
cephclient_tag:     "{{ cephclient_version|default(ceph_version) }}"
openstackclient_tag: "{{ openstackclient_version|default(openstack_version) }}"
```

i.e. the release train governs the deployed tag (concrete pins live in
the train files `ceph-*.yml` / `openstack-*.yml`), and the role default
is only a fallback. But `iter_role_pins()` decided stream-resolution by
reading **only** the generics manager template
(`generics/environments/manager/images.yml`), which omits these two
aliases — so their role defaults were treated as canonical role pins.

## Fix

Union the stream-resolved set from the container template on top of the
generics one in `iter_role_pins()`. From the real container template
this adds exactly `cephclient` and `openstackclient` (nothing else
matches the `<name>_version|default` shape). `role_shadows` shares
`iter_role_pins()` and benefits identically.

Also declare the container template in `role_unpinned`'s `INPUT_FILES`:
the driver resolves source repos from each selected plugin's
`INPUT_FILES`, so without it, running `role_unpinned` alone in remote
mode would read an unresolved repo. `role_shadows` already declared it.

## Verification

Against the local checkouts: `role_unpinned` drops from **11 to 9**
actionable findings (`cephclient` and `openstackclient` removed);
`role_shadows` unchanged. Two new tests (a role stream-wired only in the
container template must not surface as unpinned; `role_unpinned` must
declare the container template as an input). Full suite 333 passed;
black + flake8 clean.