### PR TITLE
drift: allowlist kepler as role-managed

### DIFF
--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -34,6 +34,9 @@ allow:
   # rsync import sidecar (disabled by default) that tracks latest by design.
   - {plugin: role_unpinned, image: httpd, reason: "OSISM httpd role (Apache static/proxy); role-managed rolling 'alpine' tag by design, not release-pinned"}
   - {plugin: role_unpinned, image: httpd_data, reason: "one-shot rsync data-import sidecar (httpd_data_enable off by default); tracks registry.osism.tech/osism/rsync:latest by design"}
+  - plugin: role_unpinned
+    image: kepler
+    reason: "energy exporter; role-managed via registry.osism.tech/quay, Renovate-tracked in the kepler role, not release-pinned (osism/issues#1403)"
   # Not deployed in this OSISM series (cf. inventory IGNORE_NOT_DEPLOYED).
   - {plugin: kolla_version_chain_upstream, image: cyborg, reason: "not deployed in this series"}
   - {plugin: kolla_version_chain_upstream, image: tacker, reason: "not deployed in this series"}


### PR DESCRIPTION
`role_unpinned` flags `kepler`: its tag is pinned in the role default with no canonical release `base.yml` pin. This is intentional — kepler is an energy exporter deploying to monitoring nodes (like `scaphandre` / `stepca` / `dnsmasq`), role-managed rather than wired into the manager render template.

Add a `role_unpinned` allowlist entry recording it as role-managed, which clears the finding (verified: kepler moves to allowlisted, 0 stale).

Companion to the kepler role change (mirror + bump + Renovate tracking) in `osism/ansible-collection-services`.

Part of osism/issues#1403.