### PR TITLE
drift: add rolling_pin rolling-tag detector

### DIFF
--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -37,6 +37,13 @@ allow:
   - plugin: role_unpinned
     image: kepler
     reason: "energy exporter; role-managed via registry.osism.tech/quay, Renovate-tracked in the kepler role, not release-pinned (osism/issues#1403)"
+  # --- rolling_pin ---
+  # base.yml pins whose value is a rolling tag but are rolling by design or not
+  # deployed. substation is deliberately NOT here: it deploys 'latest' on a live
+  # service and upstream publishes immutable tags, so it is a live finding to be
+  # pinned + wired (osism/issues#1404).
+  - {plugin: rolling_pin, image: tempest, reason: "kolla-built test image; 'latest' by design, not a deployed reproducible service"}
+  - {plugin: rolling_pin, image: sonic_vs, reason: "testbed/mirror-only image (not deployed via a role or the manager render); 'latest' by design"}
   # Not deployed in this OSISM series (cf. inventory IGNORE_NOT_DEPLOYED).
   - {plugin: kolla_version_chain_upstream, image: cyborg, reason: "not deployed in this series"}
   - {plugin: kolla_version_chain_upstream, image: tacker, reason: "not deployed in this series"}

--- a/src/drift-config.yml
+++ b/src/drift-config.yml
@@ -19,6 +19,7 @@ plugins:
   release_vs_manager: {enabled: true}
   role_shadows: {enabled: true}
   role_unpinned: {enabled: true}
+  rolling_pin: {enabled: true}
   image_orphan: {enabled: true}
   kolla_version_chain_inner: {enabled: true}
   kolla_version_chain_upstream: {enabled: true}

--- a/src/osism_drift/drift/__init__.py
+++ b/src/osism_drift/drift/__init__.py
@@ -16,6 +16,7 @@ from osism_drift.drift import (
     release_vs_manager,
     role_shadows,
     role_unpinned,
+    rolling_pin,
 )
 
 KOLLA_PLUGINS = [
@@ -31,7 +32,13 @@ KOLLA_PLUGINS = [
     kolla_inventory,
 ]
 
-IMAGE_PLUGINS = [release_vs_manager, role_shadows, role_unpinned, image_orphan]
+IMAGE_PLUGINS = [
+    release_vs_manager,
+    role_shadows,
+    role_unpinned,
+    rolling_pin,
+    image_orphan,
+]
 
 PLUGIN_GROUPS = {"image": IMAGE_PLUGINS, "kolla": KOLLA_PLUGINS}
 

--- a/src/osism_drift/drift/rolling_pin.py
+++ b/src/osism_drift/drift/rolling_pin.py
@@ -1,0 +1,65 @@
+"""rolling_pin plugin: release base.yml pins whose value is a rolling tag."""
+
+from osism_drift import release, source
+from osism_drift.model import DriftEntry
+
+NAME = "rolling_pin"
+SHOW_VALUES = True
+DESCRIPTION = (
+    "Detect release/<version>/base.yml docker_images pins whose value is a "
+    "rolling tag (latest/main/...), which deploys a non-reproducible image."
+)
+INPUT_FILES = [
+    ("release", "<release_version>/base.yml"),
+]
+SUMMARY = "{n} release base.yml pins set to a rolling tag (non-reproducible):"
+REMEDIATION = (
+    "replace the rolling tag with a concrete, immutable version in release "
+    "base.yml (and wire <alias>_tag into the manager render template if the "
+    "image deploys via a role default), or allowlist it if the image is "
+    "rolling by design (e.g. a kolla-built test image)."
+)
+
+# Curated denylist of rolling (mutable) tag values, matched case-insensitively.
+# A denylist rather than a "not-semver" heuristic so odd-but-pinned tags like
+# `6.1-23.10_beta` are never mistaken for rolling.
+ROLLING_TAGS = frozenset(
+    {
+        "latest",
+        "main",
+        "master",
+        "stable",
+        "edge",
+        "nightly",
+        "rolling",
+        "dev",
+        "devel",
+        "develop",
+        "head",
+        "current",
+    }
+)
+
+
+def run(config, allowlist, verbose: bool = False) -> list:
+    release_bytes = source.read("release", f"{config.release_version}/base.yml", config)
+    docker_images = release.parse_release(release_bytes)
+
+    base_src = f"release/{config.release_version}/base.yml"
+    drifts = []
+    for key, value in docker_images.items():
+        if value.lower() not in ROLLING_TAGS:
+            continue
+        d = DriftEntry(
+            plugin=NAME,
+            image=key,
+            alias=key,
+            expected="a concrete, immutable tag",
+            found=value,
+            expected_src=base_src,
+            found_src=base_src,
+            summary=SUMMARY,
+            remediation=REMEDIATION,
+        )
+        drifts.append(allowlist.apply(d))
+    return drifts

--- a/tests/image_drift/test_plugin_registry.py
+++ b/tests/image_drift/test_plugin_registry.py
@@ -13,6 +13,7 @@ def test_image_plugins_registered():
     assert "release_vs_manager" in names
     assert "role_shadows" in names
     assert "role_unpinned" in names
+    assert "rolling_pin" in names
     assert "image_orphan" in names
 
 
@@ -28,6 +29,11 @@ def test_role_unpinned_enabled_in_config():
 def test_image_orphan_enabled_in_config():
     cfg = yaml.safe_load(_CONFIG_PATH.read_text())
     assert cfg["plugins"]["image_orphan"]["enabled"] is True
+
+
+def test_rolling_pin_enabled_in_config():
+    cfg = yaml.safe_load(_CONFIG_PATH.read_text())
+    assert cfg["plugins"]["rolling_pin"]["enabled"] is True
 
 
 def test_each_plugin_has_required_metadata():

--- a/tests/image_drift/test_rolling_pin.py
+++ b/tests/image_drift/test_rolling_pin.py
@@ -1,0 +1,93 @@
+import pytest
+from osism_drift.config import Allowlist, AllowEntry, Config, PluginCfg, Remote
+from osism_drift.drift import rolling_pin
+
+_BASE_YML = """\
+---
+manager_version: latest
+docker_images:
+  substation: 'latest'
+  tempest: 'latest'
+  sonic_vs: 'latest'
+  edgy: main
+  growing: develop
+  shouty: LATEST
+  ara_server: '1.7.5'
+  weird_but_pinned: '6.1-23.10_beta'
+"""
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    base = tmp_path / "release" / "latest"
+    base.mkdir(parents=True)
+    (base / "base.yml").write_text(_BASE_YML)
+    return Config(
+        remote=Remote("https://x/", "https://y/", "main", "osism"),
+        base_dirs=(str(tmp_path),),
+        release_version="latest",
+        plugins={"rolling_pin": PluginCfg(enabled=True)},
+        sources={},
+    )
+
+
+def _by_image(drifts):
+    return {d.image: d for d in drifts}
+
+
+def test_rolling_pins_flagged(cfg):
+    """Every docker_images value in the rolling set is flagged, case-insensitively."""
+    drifts = _by_image(rolling_pin.run(cfg, Allowlist(())))
+    assert set(drifts) == {
+        "substation",
+        "tempest",
+        "sonic_vs",
+        "edgy",
+        "growing",
+        "shouty",
+    }
+
+
+def test_concrete_pin_not_flagged(cfg):
+    """A concrete semver pin is never a candidate."""
+    assert "ara_server" not in _by_image(rolling_pin.run(cfg, Allowlist(())))
+
+
+def test_odd_but_pinned_not_flagged(cfg):
+    """A denylist (not a not-semver heuristic) leaves odd-but-immutable tags alone."""
+    assert "weird_but_pinned" not in _by_image(rolling_pin.run(cfg, Allowlist(())))
+
+
+def test_top_level_key_ignored(cfg):
+    """Only docker_images is scanned; the top-level manager_version is out of scope."""
+    assert "manager_version" not in _by_image(rolling_pin.run(cfg, Allowlist(())))
+
+
+def test_entry_fields(cfg):
+    """The finding names the release key and shows the rolling value; actionable."""
+    d = _by_image(rolling_pin.run(cfg, Allowlist(())))["substation"]
+    assert d.image == "substation"
+    assert d.alias == "substation"
+    assert d.found == "latest"
+    assert d.expected == "a concrete, immutable tag"
+    assert d.expected_src == "release/latest/base.yml"
+    assert d.severity == "actionable"
+    assert not d.allowlisted
+
+
+def test_allowlist_marks_entry(cfg):
+    """A rolling-by-design pin is marked allowlisted, not dropped."""
+    al = Allowlist(
+        (
+            AllowEntry(
+                plugin="rolling_pin",
+                image="tempest",
+                alias=None,
+                found_src=None,
+                reason="rolling by design",
+            ),
+        )
+    )
+    drifts = _by_image(rolling_pin.run(cfg, al))
+    assert drifts["tempest"].allowlisted
+    assert not drifts["substation"].allowlisted


### PR DESCRIPTION
## What

Adds a new drift detector, `rolling_pin`, to the drift-detection tooling. It
flags any `release/<version>/base.yml` `docker_images` pin whose **value** is a
rolling/mutable tag (`latest`, `main`, `master`, `stable`, `edge`, `nightly`,
`rolling`, `dev`, `devel`, `develop`, `head`, `current` — case-insensitive
denylist). Such pins deploy non-reproducible images.

## Why

A rolling tag on a deployed image escaped **every** existing check, because the
dead `base.yml` pin happened to *agree* with whatever actually deployed:

- `release_vs_manager` — skips it (unwired to the manager render)
- `role_unpinned` — treats it as pinned (it *has* a `base.yml` pin)
- `role_shadows` — silent, because `base.yml` == the role default (`latest` == `latest`)

`substation` (`substation: latest`, deployed via its role) was the exemplar: never
reproducible, invisible to the report.

## Design

- **Value-only detection** — reads `base.yml` alone; does not model deploy paths.
  The only thing a deploy-scoped condition would additionally exclude today is one
  mirror-only rolling pin (`sonic_vs`), which is cheaper to allowlist than to model
  both paths.
- **Denylist, not a not-semver heuristic** — so odd-but-immutable tags (e.g.
  `6.1-23.10_beta`) are never mistaken for rolling.

## Allowlist

- `tempest` — kolla-built test image, `latest` by design
- `sonic_vs` — mirror/testbed-only, not deployed via a role or the manager render

## Status: preventive — no live finding today

The motivating case, `substation`, has already been pinned to a concrete tag and
wired since this branch was first cut (all three PRs merged):

  - osism/release#2588
  - osism/container-image-osism-ansible#763
  - osism/ansible-collection-services#2138

Against current `main`, `rolling_pin` therefore flags only `tempest` and
`sonic_vs` — both allowlisted — so it produces **zero actionable findings** and
does **not** change the drift job's exit status. The detector is a **preventive
guard**: it will catch the next rolling-on-deployed pin at the moment it is
introduced, closing the class of bug that let `substation` hide. See
osism/issues#1404 for the substation remediation this complements.

## Testing

- `tox -e drift-test` — 339 tests pass (6 new in `test_rolling_pin.py`)
- `black` / `flake8` / `yamllint` clean (pre-commit + manual)
- End-to-end against current `latest/base.yml`: flags `tempest`/`sonic_vs` only,
  both suppressed by the allowlist → no actionable finding.

## Note

`develop` was added to the denylist for completeness/consistency with `dev`/`devel`
(all conventional rolling branch tags); no current image pin uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
