### PR TITLE
images: pin substation to reproducible tag

### DIFF
--- a/latest/base.yml
+++ b/latest/base.yml
@@ -92,7 +92,7 @@ docker_images:
   # renovate: datasource=docker depName=registry.osism.tech/osism/sonic-vs
   sonic_vs: 'latest'
   # renovate: datasource=docker depName=ghcr.io/cloudnull/substation/substation
-  substation: 'latest'
+  substation: '1774452086'
   # renovate: datasource=docker depName=hashicorp/vault
   vault: '1.21.4'
 


### PR DESCRIPTION
Pin the `substation` image from the rolling tag `latest` to the concrete
immutable epoch build tag `1774452086` (2026-03-25), so deploys are
reproducible instead of pulling whatever `:latest` is on the day.

This is the release-side pin. Companion PRs wire it into the manager render
and pin the role default; all three are tracked in the issue below.

### Sequencing with the rolling_pin detector

The `rolling_pin` detector makes the `periodic-daily` `release-tox-drift` job
report `substation: latest` as a live finding (exit 1). This pin clears that,
so it should land **before or alongside** the detector to keep the daily job
green.

- osism/release#2587

### Renovate — no config change needed

Renovate's default `docker` versioning already treats the bare-integer epoch
tags as valid, comparable versions (higher = newer) and ignores `latest`, so it
bumps the pin on new upstream builds (after the org's 3-day stability delay).
Verified against the Renovate versioning source — `versioning: loose` is **not**
required (this supersedes step 2 in the issue).

### Related

- osism/issues#1404
- osism/issues#1397