### PR TITLE
drift: document rolling_pin + kolla_image_orphan

### DIFF
--- a/docs/check-drift-image.md
+++ b/docs/check-drift-image.md
@@ -169,6 +169,29 @@ role path then alias:
            allowlist it if the image is intentionally role-managed.
       Refs: release/latest/base.yml
 
+### `rolling_pin`
+
+Flags `docker_images` pins in `release/<version>/base.yml` whose **value** is a
+rolling (mutable) tag — `latest`, `main`, `master`, `stable`, `edge`,
+`nightly`, `rolling`, `dev`, `devel`, `develop`, `head`, `current` — matched
+case-insensitively. A rolling tag in the release pin deploys a non-reproducible
+image: two deploys of the same release can pull different bytes.
+
+The match is a **curated denylist**, not a "not valid semver" heuristic, so an
+odd-but-immutable tag like `6.1-23.10_beta` is never mistaken for rolling.
+
+Unlike the other image plugins this reads a single file — the release
+`base.yml` — and does not consult the manager template or role defaults.
+
+**Inputs**: release `<release_version>/base.yml` only.
+
+**Fix**: replace the rolling tag with a concrete, immutable version in
+`base.yml` (and wire `<alias>_tag` into the manager render template if the image
+deploys via a role default), or allowlist the entry if the image is rolling by
+design — e.g. a kolla-built test image (`tempest`) or a mirror-only image
+(`sonic_vs`). A rolling tag on a *deployed* service is a real finding to fix,
+not to allowlist (cf. `substation`, osism/issues#1404).
+
 ### `image_orphan`
 
 Reports image aliases **emitted** by the generics manager render template

--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -82,7 +82,7 @@ stage or the transition into it:
    versions template and the producer's SBOM map.
 4. **deployed** — the service has ansible inventory groups to deploy into.
 
-The eight plugins run in that order, and the report renders them the same way.
+The plugins run in that order, and the report renders them the same way.
 Each opens with the stage it guards. Each is independent and can be run alone
 with `--plugin <name>`; every finding can be suppressed with an allowlist entry
 (see "Allowlist"). Service names are compared as **key spaces**, normalising
@@ -201,6 +201,33 @@ otherwise dangle after the flag is removed.
   `kolla_enablement_orphan`).
 - **Fix:** remove these vars from the listed `osism/defaults` file, or allowlist
   any intentionally kept (an OSISM invention with no upstream service).
+
+### Plugin: kolla_image_orphan
+
+**Built — an image-catalogue entry must not outlive its upstream role.** The
+image-catalogue-driven complement to the enable-flag-driven
+`kolla_enablement_orphan` → `kolla_orphan_config` path. That path only flags a
+removed service's companion vars while OSISM still defines its `enable_<svc>`
+flag; a service upstream removed for which OSISM never had an enable flag leaves
+its `<svc>_image` / `<svc>_tag` catalogue entries undetected. This check keys off
+the catalogue instead: for each OSISM kolla `*_image` (excluding `*_image_full`)
+and `*_tag` var in `osism/defaults` `all/*images-kolla*.yml`, it flags the var
+when its **name** is absent from upstream kolla-ansible role defaults across
+**every** supported release. It is a pure variable-name set-diff over the union
+of supported refs — no image-name resolution or alias chains — and both suffixes
+are tested independently. Restricting to the `*images-kolla*` catalogue glob
+keeps non-kolla images (ceph, cilium, k3s) out of the comparison. An empty OSISM
+catalogue match or an empty upstream union is a hard error, since either would
+turn the set-diff into a silent all-clear or a mass false positive.
+
+    python3 src/check-drift.py --group kolla --plugin kolla_image_orphan
+
+- **Reads:** `osism/defaults` `all/*images-kolla*.yml`; `openstack/kolla-ansible`
+  `ansible/roles/*/defaults/main.yml` (`*_image` / `*_tag`) per resolved release
+  ref, unioned across the supported range.
+- **Fix:** remove the orphaned `<svc>_image` / `<svc>_tag` var from the listed
+  catalogue file, or allowlist any intentionally kept (an OSISM-built image with
+  no upstream kolla-ansible role, e.g. mariabackup, tempest).
 
 ### Plugin: kolla_secrets_orphan
 


### PR DESCRIPTION
## What

Two `check-drift.py` plugins were registered in the plugin groups and enabled
in `drift-config.yml` — so they run — but neither had a section in the
reference docs. This documents both and removes a stale count.

- `docs/check-drift-image.md`: new `rolling_pin` section (curated rolling-tag
  denylist; reads only `base.yml`).
- `docs/check-drift-kolla.md`: new `kolla_image_orphan` section, placed after
  its enable-flag-driven `kolla_orphan_config` counterpart.
- Drop the hard-coded "eight plugins" count from the kolla doc overview — it
  was already wrong (ten kolla plugins) and goes stale whenever a plugin is
  added.

## Why

All 15 registered plugins now have a documented section; before this,
`rolling_pin` and `kolla_image_orphan` ran but were undocumented.

Docs-only; no code or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)