### PR TITLE
latest: cap ansible-core below 2.19

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -132,6 +132,31 @@
         "latest/base.yml"
       ],
       "groupName": "osism"
+    },
+    {
+      "description": [
+        "The ansible containers share one Redis fact cache, and ansible-core 2.19",
+        "namespaces cache entries with an s1_ key prefix, so a core that crosses",
+        "2.19 writes where kolla-ansible and ceph-ansible cannot read. Those two",
+        "cap ansible-core at <2.19 and <2.17 respectively, and cloud.common 5.0.0",
+        "declares requires_ansible >=2.15.0,<2.19. Blocking minor is deliberate:",
+        "for ansible-core, 2.18 -> 2.19 is a minor bump. The per-release files",
+        "already have this policy; base.yml was the only ansible pin left",
+        "floating. Lift once kolla-ansible gathers its own facts or the cache is",
+        "split per container. See osism/issues#1420."
+      ],
+      "matchDepNames": [
+        "ansible",
+        "ansible-core"
+      ],
+      "matchFileNames": [
+        "latest/base.yml"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/latest/base.yml
+++ b/latest/base.yml
@@ -2,9 +2,9 @@
 manager_version: latest
 
 # renovate: datasource=pypi depName=ansible
-ansible_version: '12.2.0'
+ansible_version: '11.10.0'
 # renovate: datasource=pypi depName=ansible-core
-ansible_core_version: '2.19.11'
+ansible_core_version: '2.18.18'
 
 # renovate: datasource=github-tags depName=osism/defaults
 defaults_version: 'v0.20260712.0'


### PR DESCRIPTION
## Problem

The `current` and `next` testbed lanes have TIMED_OUT at the full 4.5 h Zuul
timeout every night since 2026-07-25. kolla-ansible's `common` role fails with
`ansible_facts` empty and `os_family` undefined, so `kolla_toolbox` is never
deployed and the non-aborting celery chain polls until Zuul kills the build.

Cause: `latest/base.yml` moved `ansible_core_version` to 2.19.11. ansible-core
2.19 namespaces fact-cache entries with an `s1_` key prefix, so
`osism-ansible:latest` writes into a keyspace `kolla-ansible:2025.1` (2.18.18)
and `ceph-ansible:reef` (2.16.19) cannot read — and they share one Redis fact
cache. kolla has no fallback, because OSISM splits kolla's `site.yml` and the
splitter drops the `gather-facts.yml` import while forcing `gather_facts: false`.

`base.yml` cannot cross 2.19 while it shares a cache with containers that cannot
follow. The binding constraint is **kolla-ansible 2025.1**, which requires
`ansible-core>=2.17,<2.19` upstream and is the container that actually fails.
ceph-ansible is not the problem here: it caps `<2.17`, but it runs
`ceph-configure-lvm-volumes.yml` with an unconditional gather over `ceph-osd`,
which writes unprefixed cache entries and is the only reason `node-3/4/5`
survive at all. Raising ceph-ansible's core, or isolating its cache, would
remove that and fail all seven hosts instead of four.

## Change

- `latest/base.yml`: `ansible_core_version` 2.19.11 -> 2.18.18. All 22
  collections pinned in this file were checked against Galaxy `requires_ansible`
  — none needs `>=2.19`, so 2.18.18 satisfies every one. (`cloud.common` 5.0.0
  declares `<2.19`, but nothing uses that collection — no OSISM code references
  it and nothing pinned depends on it — so it is not offered here as a
  justification; it wants removing separately.)
- `latest/base.yml`: `ansible_version` 12.2.0 -> 11.10.0. Cosmetic only; the
  field is not installed for any live build. Reverted so the pair is not
  misleading.
- `.github/renovate.json`: disable major and minor `ansible` / `ansible-core`
  updates for `latest/base.yml`. Blocking minor is the point — for ansible-core,
  2.18 -> 2.19 is itself a minor bump. The per-release files already carry this
  policy; `base.yml` was the only ansible pin left floating. Appended last so the
  existing `groupName: "ansible"` rule keeps applying for patch updates.

## Verification

Reaches CI at the next nightly `osism-ansible:latest` rebuild, then the
following midnight run. Note a green run confirms the trigger, not the
mechanism — the mechanism is already confirmed separately, by reading the 2.19
`PluginInterposer` source and by reproducing the failure outside the testbed
with two ansible-core venvs against a local Redis.

## Lifting the cap

Not before kolla-ansible can gather its own facts. Splitting the shared fact
cache first would make things worse rather than better: kolla would get an empty
cache and still no gather step, failing every host instead of only those the
ceph-ansible OSD play happens to rescue.

## Related

Full analysis, including the reproduction and the cost of holding the cap:

- osism/issues#1420

Blocked while this cap holds, since `ansible` 14 requires `ansible-core~=2.21.2`:

- osism/release#2623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

