### PR TITLE
latest: use unmaintained 2024.1 sources

### DIFF
--- a/latest/openstack-2024.1.yml
+++ b/latest/openstack-2024.1.yml
@@ -43,25 +43,25 @@ infrastructure_projects:
   tgtd:
 
 openstack_projects:
-  aodh: stable-2024.1
-  barbican: stable-2024.1
-  blazar: stable-2024.1
-  ceilometer: stable-2024.1
-  cinder: stable-2024.1
-  designate: stable-2024.1
-  glance: stable-2024.1
+  aodh: unmaintained-2024.1
+  barbican: unmaintained-2024.1
+  blazar: unmaintained-2024.1
+  ceilometer: unmaintained-2024.1
+  cinder: unmaintained-2024.1
+  designate: unmaintained-2024.1
+  glance: unmaintained-2024.1
   gnocchi: stable/4.6
-  horizon: stable-2024.1
-  ironic: stable-2024.1
-  keystone: stable-2024.1
-  magnum: stable-2024.1
-  manila: stable-2024.1
-  masakari: stable-2024.1
-  neutron-dynamic-routing: stable-2024.1
-  neutron-vpnaas: stable-2024.1
-  neutron: stable-2024.1
-  nova: stable-2024.1
-  octavia: stable-2024.1
-  placement: stable-2024.1
-  skyline-apiserver: stable-2024.1
-  skyline-console: stable-2024.1
+  horizon: unmaintained-2024.1
+  ironic: unmaintained-2024.1
+  keystone: unmaintained-2024.1
+  magnum: unmaintained-2024.1
+  manila: unmaintained-2024.1
+  masakari: unmaintained-2024.1
+  neutron-dynamic-routing: unmaintained-2024.1
+  neutron-vpnaas: unmaintained-2024.1
+  neutron: unmaintained-2024.1
+  nova: unmaintained-2024.1
+  octavia: unmaintained-2024.1
+  placement: unmaintained-2024.1
+  skyline-apiserver: unmaintained-2024.1
+  skyline-console: unmaintained-2024.1


### PR DESCRIPTION
> [!IMPORTANT]
> Cross-repo change. **Merge this PR first**, before the companion change in
> `container-images-kolla`. Rationale in [Merge order](#merge-order) below —
> the reverse order builds successfully while silently dropping nine fixes.

OpenStack 2024.1 (Caracal) is in the unmaintained phase upstream: the
`stable/2024.1` branches were renamed to `unmaintained/2024.1`. The
per-project refs in `latest/openstack-2024.1.yml` still pointed at
`stable-2024.1`, which is the name of the branch artifact on
`tarballs.opendev.org` that the 2024.1 container images are built from.

Those artifacts still resolve, but opendev stopped regenerating them at the
rename, so they are frozen at the final `stable/2024.1` state. Nothing fails —
the frozen tarball is still served, `wget` succeeds and `kolla-build` reports
no error — so the 2024.1 images have silently been built from Sep/Oct 2025
sources ever since.

## Impact

No upstream fix merged to `unmaintained/2024.1` can reach a 2024.1 image.

Confirmed by inspecting the published image rather than its metadata: the
`kolla/neutron-server:2024.1` image rebuilt on 2026-07-30 ships
`neutron-24.2.2.dev23`, and its `onboard_network_subnets` still has no
ownership check — it remains vulnerable to CVE-2026-55707, whose fix is
merged upstream on `unmaintained/2024.1`.

- https://osism.tech/docs/appendix/security/ossa-2026-032/
- https://bugs.launchpad.net/neutron/+bug/2152113
- https://review.opendev.org/c/openstack/neutron/+/999186

Counting only commits that touch runtime code (`neutron/` excluding
`neutron/tests/`), 14 neutron fixes are missing from published 2024.1 images
beyond the two OSISM carries downstream. Among them a second security fix
(`b0411e51be`, PF GET/PUT parent floating IP validation — backported
downstream for 2024.2 but never for 2024.1), an OVN security-group rule that
can silently fail to apply (`37553716ea`), and a data-loss bug
(`4f27134e92`). Every other 2024.1 project is frozen the same way; keystone
is 12 commits behind, nova and cinder at least 19 and 4.

## Change

Point the 21 `openstack_projects` refs at `unmaintained-2024.1`, which opendev
does keep current. `gnocchi` stays on `stable/4.6` — it follows its own branch
naming and is unaffected.

## Verification

- All 21 projects plus `requirements` were confirmed to have an
  `unmaintained-2024.1` artifact (HTTP 200 each). This matters because
  `003-patch.sh` runs `wget ... || exit 2`, so a single missing artifact
  would break the build.
- `templates/<version>/kolla-build.conf.j2` interpolates the ref straight into
  `location = tarballs/{{ project.repository }}-{{ project.version }}.tar.gz`,
  so the new value resolves to `<project>-unmaintained-2024.1.tar.gz`.
- The post-change patch set was applied against the unmaintained tarballs the
  way `003-patch.sh` does it (cumulative, `sort` order): keystone 4/4, nova
  1/1, cinder 1/1, neutron-dynamic-routing 1/1, neutron none remaining — all
  apply.
- `neutron-unmaintained-2024.1.tar.gz` was extracted and confirmed to contain
  the ownership check.

## Merge order

There is no `gate` pipeline, so the two PRs cannot be co-merged and one order
has to be chosen.

| Order | Effect in the window between merges |
|---|---|
| **This PR first** | New refs while the nine now-upstream patches are still present → `003-patch.sh` fails on an already-applied patch. Loud, and nothing bad ships. A red `periodic-midnight` in between is expected. |
| Companion first | Patches removed while refs are still frozen → builds succeed and **silently drop nine security fixes** from published 2024.1 images. |

## Notes

- No precedent: no `latest/openstack-*.yml` has previously had its
  `openstack_projects` refs moved off `stable-<version>`. 2024.2 stays on a
  frozen `stable-2024.2` tarball plus downstream patches, which is forced
  there — it is EOL and has no `unmaintained` branch. 2024.1 still has one,
  which is what makes this possible.
- Limited lifespan: when 2024.1 reaches EOL its branch is deleted and the
  build falls back to a frozen tarball plus patches, as 2024.2 is now. This
  buys a maintained window; it does not remove the pattern. A build-time
  staleness check would.
- `UpgradeImpact`: rolling `:2024.1` images advance roughly nine months of
  upstream commits across 21 projects. That is the intent, but it is a larger
  delta than a normal rebuild.

## Companion PR

- osism/container-images-kolla#762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
