### PR TITLE
Add drift check for stale OpenStack source refs

### DIFF
--- a/src/drift-config.yml
+++ b/src/drift-config.yml
@@ -31,3 +31,4 @@ plugins:
   kolla_orphan_config: {enabled: true}
   kolla_image_orphan: {enabled: true}
   kolla_secrets_orphan: {enabled: true}
+  kolla_source_ref_phase: {enabled: true}

--- a/src/osism_drift/drift/__init__.py
+++ b/src/osism_drift/drift/__init__.py
@@ -11,6 +11,7 @@ from osism_drift.drift import (
     kolla_mirror_verbatim,
     kolla_orphan_config,
     kolla_secrets_orphan,
+    kolla_source_ref_phase,
     kolla_version_chain_inner,
     kolla_version_chain_upstream,
     release_vs_manager,
@@ -20,6 +21,7 @@ from osism_drift.drift import (
 )
 
 KOLLA_PLUGINS = [
+    kolla_source_ref_phase,
     kolla_enablement_orphan,
     kolla_groupvars_missing,
     kolla_mirror_verbatim,

--- a/src/osism_drift/drift/kolla_source_ref_phase.py
+++ b/src/osism_drift/drift/kolla_source_ref_phase.py
@@ -1,0 +1,253 @@
+"""kolla_source_ref_phase: an OpenStack source ref left behind by a phase change.
+
+Upstream renames stable/<release> to unmaintained/<release>, then deletes the
+branch at EOL. tarballs.opendev.org keeps serving the artifact for a retired
+branch name but stops regenerating it, so a build that still asks for
+<project>-stable-<release>.tar.gz keeps succeeding while its sources sit frozen
+at the moment of the rename. Nothing fails, so nothing prompts a fix.
+
+For each supported release, this compares the ref configured in release
+latest/openstack-<R>.yml against the latest lifecycle phase opendev actually
+publishes a tarball for. A later phase being available means the configured
+artifact is frozen and the build no longer receives upstream fixes.
+
+Artifact-driven rather than branch-driven on purpose. The question is which
+tarball the build consumes, and probing the published set answers it directly:
+no upstream repository owner is needed for every project, and the check
+self-limits at EOL, where no later artifact exists and the frozen tarball is the
+only option.
+
+Existence is probed with one HEAD per candidate rather than by reading the
+per-project index listing. The listings are large (nova's is ~1.4 MB and 10k
+entries) and timed out intermittently in practice, which for a nightly check
+means noise; a HEAD is a few hundred bytes and answers exactly the question.
+
+A probe that neither confirms nor denies (an outage, a throttled response) makes
+that one ref unverified, not clean: it is reported as such rather than aborting
+the run, so one upstream blip cannot discard every other plugin's findings while
+still never being read as "no drift". See ProbeInconclusive.
+"""
+
+import sys
+from dataclasses import dataclass
+
+from osism_drift import enablement, http, source
+from osism_drift.http import SourceError
+from osism_drift.model import DriftEntry
+
+NAME = "kolla_source_ref_phase"
+DESCRIPTION = (
+    "Flag OpenStack source refs in the release manifests that a later upstream "
+    "lifecycle phase has superseded, so the build reads a frozen tarball."
+)
+INPUT_FILES = [
+    ("release", "latest/openstack-<release>.yml"),
+]
+# Hosts this plugin reads that no --base-dir can stand in for: the question is
+# what upstream publishes right now, which no checkout records. The driver
+# refuses a local-only run that selects this plugin rather than reaching the
+# network behind the operator's back.
+EXTERNAL_HOSTS = ("tarballs.opendev.org",)
+SUMMARY = (
+    "{n} source refs whose tarball is no longer regenerated upstream because a "
+    "later lifecycle phase is published, so these builds use frozen sources:"
+)
+# Fallback only. Findings carry a per-entry remediation naming the concrete
+# target phase and file; see remediation_for().
+REMEDIATION = (
+    "set the openstack_projects ref to the latest published phase in "
+    "release/latest/openstack-<release>.yml, and drop any downstream patch the "
+    "newer sources already carry. Upstream renames stable/<release> to "
+    "unmaintained/<release> and goes on serving the stable-<release> tarball "
+    "without regenerating it, so nothing breaks and the ref has to be moved "
+    "deliberately. Allowlist the project if it is deliberately pinned to a "
+    "frozen tarball."
+)
+
+_URL = "https://tarballs.opendev.org/openstack/{project}/{project}-{ref}.tar.gz"
+# Group-level, so all findings render as one block: the per-entry line already
+# carries the project and both phases. A per-project value here would split the
+# report into one group per finding.
+EXPECTED_SRC = "tarballs.opendev.org/openstack/<project>/"
+# Lifecycle order, earliest first. Only phases *after* the configured one are
+# probed: an earlier phase's tarball keeps being served after the rename, so its
+# presence says nothing about freshness.
+#
+# Only the phases opendev publishes a tarball for belong here. Upstream also
+# tags the transitions -- <release>-eom when the stable branch becomes
+# unmaintained, <release>-eol when the unmaintained branch is deleted -- but no
+# tarball is built for a tag (verified 404 for every project and series
+# checked). Listing them would spend two probes per project that can never
+# match, and would point the reader at a target they cannot download.
+_PHASES = ("stable-{r}", "unmaintained-{r}")
+
+# What an unverified ref reports instead of a target phase. Distinct from a
+# clean result on purpose: the check did not establish that the ref is current,
+# it failed to establish anything.
+UNRESOLVED_EXPECTED = "(unknown: probe failed)"
+UNRESOLVED_SUMMARY = (
+    "{n} source refs whose upstream lifecycle phase could not be established, "
+    "so their freshness is unknown rather than confirmed current:"
+)
+
+
+class ProbeInconclusive(SourceError):
+    """A phase probe that neither confirmed nor denied that a tarball exists.
+
+    The distinction this plugin exists to protect is between "no later phase is
+    published" and "we could not find out": collapsing the second into the first
+    reports no drift and silently reinstates the blind spot. But that guard
+    belongs on the finding, not on the run -- aborting would discard every other
+    plugin's findings over one upstream hiccup -- so the plugin catches this per
+    project and reports the ref as unverified.
+
+    Derives from SourceError so that if one ever escapes uncaught, the run
+    degrades to the ordinary source-failure abort instead of a traceback.
+
+    `kind` is the coarse cause ("HTTP 503", "network error"), used for grouping
+    so that refs failing the same way share one report block; `detail` is the
+    full message, including the URL.
+    """
+
+    def __init__(self, kind: str, detail: str):
+        super().__init__(detail)
+        self.kind = kind
+        self.detail = detail
+
+
+def remediation_for(release: str, latest: str) -> str:
+    """Remediation naming the concrete target phase, shared per (release, phase).
+
+    Kept free of the project name so every project moving to the same phase
+    groups into one report block rather than one block each.
+    """
+    return (
+        f"set these openstack_projects refs to {latest} in "
+        f"release/latest/openstack-{release}.yml, and drop any downstream patch "
+        f"the newer sources already carry. Upstream stops regenerating a "
+        f"phase's tarball once the release moves on but goes on serving it, so "
+        f"nothing breaks and {latest} has to be set deliberately. Allowlist a "
+        f"project that is deliberately pinned to the frozen tarball."
+    )
+
+
+def unresolved_remediation(kind: str) -> str:
+    """Remediation for refs a failed probe left unverified.
+
+    Keyed on `kind` alone -- no project, no URL -- so that every ref that failed
+    the same way groups into one report block. The URLs reach stderr under -v.
+    """
+    return (
+        f"re-run the check: probing {EXTERNAL_HOSTS[0]} for these projects "
+        f"failed with {kind}, so whether a later lifecycle phase is published "
+        f"is unknown. Treat this as an incomplete result, not a clean one -- "
+        f"these refs may be reading frozen sources. Run with -v for the URLs."
+    )
+
+
+def tarball_exists(project: str, ref: str) -> bool:
+    """True if opendev publishes <project>-<ref>.tar.gz.
+
+    Only a 404 counts as absent. Any other unsuccessful status raises
+    ProbeInconclusive, because reading an outage or a throttled response as "no
+    later phase published" would silently report no drift -- the exact blind
+    spot this plugin closes.
+    """
+    url = _URL.format(project=project, ref=ref)
+    try:
+        r = http.head(f"probing {project} {ref}", url, ok=(404,))
+    except SourceError as e:
+        kind = f"HTTP {e.status}" if e.status else "network error"
+        raise ProbeInconclusive(kind, str(e)) from e
+    return r.status_code == 200
+
+
+def _later_phases(release: str, configured: str) -> list:
+    """Lifecycle phases for `release` that come after `configured`."""
+    refs = [t.format(r=release) for t in _PHASES]
+    if configured not in refs:
+        return []
+    return refs[refs.index(configured) + 1 :]
+
+
+@dataclass
+class Scan:
+    """What one release's phase scan concluded.
+
+    `stale` is [(project, configured, latest)] for refs a later published phase
+    supersedes. `unresolved` is [(project, configured, kind, detail)] for refs
+    whose phase a failed probe left undecided.
+    """
+
+    stale: list
+    unresolved: list
+
+
+def scan(refs: dict, release: str, exists) -> Scan:
+    """Classify each openstack_projects ref for `release`.
+
+    `exists(project, ref)` reports whether that tarball is published, and may
+    raise ProbeInconclusive. Refs that do not name the release are skipped: a
+    project on its own branch scheme (e.g. gnocchi at stable/4.6) does not
+    follow the release lifecycle.
+
+    A project whose probe is inconclusive is reported unresolved and never also
+    stale: with one candidate's answer unknown, the latest published phase is
+    unknown too, so naming a target would be a guess.
+    """
+    result = Scan([], [])
+    for project, configured in sorted(refs.items()):
+        if not configured or release not in configured:
+            continue
+        latest = None
+        try:
+            for ref in _later_phases(release, configured):
+                if exists(project, ref):
+                    latest = ref
+        except ProbeInconclusive as e:
+            result.unresolved.append((project, configured, e.kind, e.detail))
+            continue
+        if latest is None:
+            continue
+        result.stale.append((project, configured, latest))
+    return result
+
+
+def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
+    """Return drifts for source refs superseded by a later published phase, plus
+    one entry per ref a failed probe left unverified."""
+    drifts = []
+    for release in enablement.release_range(config):
+        refs = enablement.parse_source_refs(
+            source.read("release", f"latest/openstack-{release}.yml", config)
+        )
+        found_src = f"osism/release latest/openstack-{release}.yml"
+        result = scan(refs, release, tarball_exists)
+        for project, configured, latest in result.stale:
+            d = DriftEntry(
+                plugin=NAME,
+                image=project,
+                alias=project,
+                expected=latest,
+                found=configured,
+                expected_src=EXPECTED_SRC,
+                found_src=found_src,
+                remediation=remediation_for(release, latest),
+            )
+            drifts.append(allowlist.apply(d))
+        for project, configured, kind, detail in result.unresolved:
+            if verbose:
+                print(f"warning: {detail}", file=sys.stderr)
+            d = DriftEntry(
+                plugin=NAME,
+                image=project,
+                alias=project,
+                expected=UNRESOLVED_EXPECTED,
+                found=configured,
+                expected_src=EXPECTED_SRC,
+                found_src=found_src,
+                summary=UNRESOLVED_SUMMARY,
+                remediation=unresolved_remediation(kind),
+            )
+            drifts.append(allowlist.apply(d))
+    return drifts

--- a/src/osism_drift/drift/plugin.py
+++ b/src/osism_drift/drift/plugin.py
@@ -4,7 +4,14 @@ from typing import Protocol
 
 
 class Plugin(Protocol):  # pylint: disable=too-few-public-methods  # interface
-    """Structural type a drift-check plugin module must satisfy."""
+    """Structural type a drift-check plugin module must satisfy.
+
+    One attribute is optional and so not declared below: EXTERNAL_HOSTS, a tuple
+    of hosts the plugin reads that are not OSISM repos and that no --base-dir can
+    stand in for. Declaring it lets the driver refuse a local-only run up front
+    (see driver._network_blocked) instead of the plugin quietly reaching the
+    network mid-run. Plugins that only read repos omit it.
+    """
 
     NAME: str
     DESCRIPTION: str

--- a/src/osism_drift/driver.py
+++ b/src/osism_drift/driver.py
@@ -53,6 +53,11 @@ def run(
         and config.plugins[p.NAME].enabled
     ]
 
+    blocked = _network_blocked(selected, config)
+    if blocked:
+        print(f"source error: {blocked}", file=sys.stderr)
+        return 2
+
     repos = {repo for p in selected for repo, _ in p.INPUT_FILES}
     try:
         resolution = source.describe_resolution(repos, config)
@@ -111,6 +116,38 @@ def run(
         report_headers,
     )
     return 1 if (actionable or stale) else 0
+
+
+def _network_blocked(selected, config) -> str | None:
+    """Message when a local-only run selected plugins that must reach the network.
+
+    --base-dir without --remote-fallback is a local-only run: source._resolve
+    errors rather than fetching a repo remotely. A plugin declaring
+    EXTERNAL_HOSTS reads something no checkout can stand in for -- what upstream
+    publishes right now, say -- so it cannot honour that mode. Refuse before any
+    comparison runs and list every such plugin at once, the way
+    source.describe_resolution reports every unresolvable repo, instead of
+    reaching the network behind the operator's back.
+    """
+    if not config.base_dirs or config.remote_fallback:
+        return None
+    needing = [
+        f"  {p.NAME:<32} needs {', '.join(hosts)}"
+        for p in selected
+        for hosts in (getattr(p, "EXTERNAL_HOSTS", ()),)
+        if hosts
+    ]
+    if not needing:
+        return None
+    return "\n".join(
+        [
+            "these plugins read hosts that no --base-dir can serve, but this is "
+            "a local-only run (--base-dir without --remote-fallback):",
+            *needing,
+            "pass --remote-fallback to allow network access, or deselect them "
+            "with --plugin.",
+        ]
+    )
 
 
 def _candidate_plugins(group, plugin_groups):

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -154,6 +154,18 @@ def parse_build_set(body: bytes) -> set:
     return keys
 
 
+def parse_source_refs(body: bytes) -> dict:
+    """openstack_projects as {project: ref}, project names verbatim.
+
+    Unlike parse_build_set the keys are not canonicalised: they index the
+    upstream source tarball names, where the real project name (e.g.
+    neutron-dynamic-routing) is what resolves. A key with no value maps to None
+    so the caller can skip it.
+    """
+    data = yaml.safe_load(body) or {}
+    return dict(data.get("openstack_projects") or {})
+
+
 def release_range(config) -> list:
     """Supported releases: config.releases override, else derived from the
     osism/release latest/openstack-*.yml file set (sorted)."""

--- a/src/osism_drift/http.py
+++ b/src/osism_drift/http.py
@@ -33,8 +33,16 @@ def _auth_headers(url: str, extra: dict | None = None) -> dict:
     return headers
 
 
-def _rate_limit_hint(r) -> str | None:
+def _rate_limit_hint(r, url: str) -> str | None:
     """A helpful hint when response `r` is a GitHub rate-limit rejection, else None.
+
+    Hints are host-scoped, because everything below describes GitHub's limits
+    specifically. A non-GitHub host gets at most a generic Retry-After echo:
+    naming raw.githubusercontent.com in a failure that came from some other
+    service would send the reader chasing the wrong one, and the --base-dir
+    advice need not apply there at all. Reachable today through a non-GitHub
+    github_raw/github_api override -- the same case _auth_headers already keeps
+    a token from leaking into.
 
     GitHub reports its primary rate limit as HTTP 403 (or, more recently, 429)
     with X-RateLimit-Remaining: 0, and secondary limits as 403/429 with a
@@ -55,6 +63,10 @@ def _rate_limit_hint(r) -> str | None:
     if r.status_code not in (403, 429):
         return None
     retry_after = r.headers.get("Retry-After")
+    if (urlparse(url).hostname or "") not in _GITHUB_HOSTS:
+        if retry_after and retry_after.isdigit():
+            return f"The host asked for a {retry_after}s wait before retrying."
+        return None
     if r.headers.get("X-RateLimit-Remaining") != "0" and retry_after is None:
         # No GitHub-API rate-limit markers. raw.githubusercontent.com is a Fastly
         # CDN that throttles per-IP and returns 429 with none of these headers, so
@@ -98,7 +110,7 @@ def _http_error(action: str, url: str, r) -> SourceError:
     """SourceError for a non-ok HTTP response, with a rate-limit hint appended
     when the response looks like GitHub throttling rather than a plain failure."""
     msg = f"HTTP {r.status_code} {action} {url}"
-    hint = _rate_limit_hint(r)
+    hint = _rate_limit_hint(r, url)
     if hint:
         msg = f"{msg} — {hint}"
     return SourceError(msg)

--- a/src/osism_drift/http.py
+++ b/src/osism_drift/http.py
@@ -2,13 +2,24 @@
 
 import datetime
 import os
+import time
 from urllib.parse import urlparse
 
 import requests
 
 
 class SourceError(Exception):
-    """Raised on any read/list failure that should abort the run."""
+    """Raised on any read/list failure that should abort the run.
+
+    `status` carries the HTTP status when the failure was an HTTP response, and
+    is None for transport failures and non-HTTP read errors. A caller that
+    treats some failures as inconclusive rather than fatal classifies on it
+    instead of parsing the message (see drift/kolla_source_ref_phase.py).
+    """
+
+    def __init__(self, message, *, status: int | None = None):
+        super().__init__(message)
+        self.status = status
 
 
 _GITHUB_HOSTS = frozenset({"github.com", "api.github.com", "raw.githubusercontent.com"})
@@ -113,7 +124,7 @@ def _http_error(action: str, url: str, r) -> SourceError:
     hint = _rate_limit_hint(r, url)
     if hint:
         msg = f"{msg} — {hint}"
-    return SourceError(msg)
+    return SourceError(msg, status=r.status_code)
 
 
 _GH_JSON = {"Accept": "application/vnd.github.v3+json"}
@@ -135,3 +146,52 @@ def _get(action: str, url: str, *, json_api: bool = False, ok=(), timeout: int =
     if not r.ok and r.status_code not in ok:
         raise _http_error(action, url, r)
     return r
+
+
+# Statuses worth one more attempt: throttling, and the server-side blips a
+# static file server emits while a backend hiccups or a maintenance window
+# starts. Everything else is a settled answer and is raised on the first try.
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+_HEAD_ATTEMPTS = 2
+_HEAD_BACKOFF = 2.0
+
+
+def head(
+    action: str,
+    url: str,
+    *,
+    ok=(),
+    timeout: int = 30,
+    attempts: int = _HEAD_ATTEMPTS,
+    sleep=time.sleep,
+):
+    """HEAD `url` with auth + a timeout; return the Response.
+
+    For existence probes. Same contract as _get: a transport failure, or a
+    non-ok status whose code is not in `ok`, raises SourceError. The caller
+    whitelists the codes that carry meaning for it (typically 404 for "absent")
+    so that an outage or a throttled response cannot be mistaken for one.
+
+    A transport failure or a transient status is retried up to `attempts` times
+    with a linear backoff, because a probe sweep makes many small requests and
+    one blip should not decide the outcome. The retry is insurance against a
+    blip, not a throttling strategy: a host that keeps refusing still raises,
+    and the caller decides what an unanswered probe means.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        final = attempt >= attempts
+        try:
+            r = requests.head(
+                url, timeout=timeout, headers=_auth_headers(url), allow_redirects=True
+            )
+        except requests.RequestException as e:
+            if final:
+                raise SourceError(f"network error {action} {url}: {e}") from e
+        else:
+            if r.ok or r.status_code in ok:
+                return r
+            if final or r.status_code not in _TRANSIENT_STATUS:
+                raise _http_error(action, url, r)
+        sleep(_HEAD_BACKOFF * attempt)

--- a/tests/kolla_drift/test_driver.py
+++ b/tests/kolla_drift/test_driver.py
@@ -1,12 +1,88 @@
 import importlib.util
 from pathlib import Path
 
+from osism_drift.config import Config, Remote
+from osism_drift.driver import _network_blocked
+
 _SPEC = importlib.util.spec_from_file_location(
     "check_drift",
     Path(__file__).resolve().parents[2] / "src" / "check-drift.py",
 )
 driver = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(driver)
+
+
+class _Repos:
+    """A plugin that only reads OSISM repos."""
+
+    NAME = "reads_repos_only"
+
+
+class _External(_Repos):
+    """A plugin that reads a host no checkout can stand in for."""
+
+    NAME = "probes_upstream"
+    EXTERNAL_HOSTS = ("tarballs.opendev.org",)
+
+
+def _cfg(**kw):
+    return Config(
+        remote=Remote(
+            "https://raw.githubusercontent.com/", "https://api.github.com/", "main"
+        ),
+        release_version="latest",
+        plugins={},
+        **kw,
+    )
+
+
+def test_local_only_run_refuses_a_plugin_that_must_reach_the_network():
+    """--base-dir without --remote-fallback is a promise of no remote reads."""
+    msg = _network_blocked([_External], _cfg(base_dirs=("/somewhere",)))
+    assert "probes_upstream" in msg
+    assert "tarballs.opendev.org" in msg
+    assert "--remote-fallback" in msg
+
+
+def test_remote_fallback_permits_the_network_read():
+    cfg = _cfg(base_dirs=("/somewhere",), remote_fallback=True)
+    assert _network_blocked([_External], cfg) is None
+
+
+def test_a_fully_remote_run_is_never_blocked():
+    """No --base-dir means every read was going to be remote anyway."""
+    assert _network_blocked([_External], _cfg()) is None
+
+
+def test_repo_only_plugins_are_not_blocked():
+    assert _network_blocked([_Repos], _cfg(base_dirs=("/somewhere",))) is None
+
+
+def test_every_offending_plugin_is_listed_at_once():
+    """Same courtesy as describe_resolution: one run, the whole list."""
+    other = type("Other", (), {"NAME": "probes_elsewhere", "EXTERNAL_HOSTS": ("x.io",)})
+    msg = _network_blocked([_External, _Repos, other], _cfg(base_dirs=("/d",)))
+    assert "probes_upstream" in msg
+    assert "probes_elsewhere" in msg
+    assert "reads_repos_only" not in msg
+
+
+def test_network_plugin_in_a_local_only_run_exits_2(capsys, tmp_path):
+    """End to end: refused before any probe, not mid-sweep."""
+    rc = driver.main(
+        [
+            "--group",
+            "kolla",
+            "--base-dir",
+            str(tmp_path),
+            "--plugin",
+            "kolla_source_ref_phase",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "tarballs.opendev.org" in err
+    assert "no --base-dir can serve" in err
 
 
 def test_base_dir_not_found_exits_2(capsys, tmp_path):

--- a/tests/kolla_drift/test_enablement_source_refs.py
+++ b/tests/kolla_drift/test_enablement_source_refs.py
@@ -1,0 +1,33 @@
+from osism_drift import enablement
+
+
+def test_parse_source_refs_returns_openstack_project_refs():
+    body = b"""
+infrastructure_projects:
+  fluentd:
+openstack_projects:
+  neutron: stable-2024.1
+  nova: unmaintained-2024.1
+"""
+    assert enablement.parse_source_refs(body) == {
+        "neutron": "stable-2024.1",
+        "nova": "unmaintained-2024.1",
+    }
+
+
+def test_parse_source_refs_preserves_hyphenated_project_names():
+    """Names index tarball URLs, so they must not be canonicalised."""
+    body = b"openstack_projects:\n  neutron-dynamic-routing: stable-2024.1\n"
+    assert enablement.parse_source_refs(body) == {
+        "neutron-dynamic-routing": "stable-2024.1"
+    }
+
+
+def test_parse_source_refs_keeps_valueless_entries():
+    """A key with no ref is reported as None so callers can skip it."""
+    body = b"openstack_projects:\n  nova:\n"
+    assert enablement.parse_source_refs(body) == {"nova": None}
+
+
+def test_parse_source_refs_empty_when_block_absent():
+    assert enablement.parse_source_refs(b"infrastructure_projects:\n  fluentd:\n") == {}

--- a/tests/kolla_drift/test_http_head.py
+++ b/tests/kolla_drift/test_http_head.py
@@ -1,0 +1,161 @@
+import pytest
+import requests
+import responses
+from osism_drift import http
+from osism_drift.http import SourceError
+
+URL = "https://tarballs.opendev.org/openstack/nova/nova-unmaintained-2024.1.tar.gz"
+GH = "https://api.github.com/repos/osism/release/contents/latest"
+
+
+def _head(*args, **kwargs):
+    """head() with the backoff wait removed, so tests don't sit in time.sleep."""
+    kwargs.setdefault("sleep", lambda _s: None)
+    return http.head(*args, **kwargs)
+
+
+@responses.activate
+def test_head_returns_the_response_for_a_published_artifact():
+    responses.add(responses.HEAD, URL, status=200)
+    assert _head("probing", URL).status_code == 200
+
+
+@responses.activate
+def test_head_returns_a_whitelisted_status_without_raising():
+    """A 404 means 'absent' to a caller that whitelists it, not a failure."""
+    responses.add(responses.HEAD, URL, status=404)
+    assert _head("probing", URL, ok=(404,)).status_code == 404
+
+
+@responses.activate
+def test_head_raises_on_a_status_that_is_not_whitelisted():
+    responses.add(responses.HEAD, URL, status=404)
+    with pytest.raises(SourceError, match="HTTP 404 probing"):
+        _head("probing", URL)
+
+
+@responses.activate
+def test_head_raises_on_server_error_even_when_404_is_whitelisted():
+    """Only 404 may mean absent; a 5xx is an outage and must not read as absent."""
+    responses.add(responses.HEAD, URL, status=503)
+    with pytest.raises(SourceError, match="HTTP 503 probing"):
+        _head("probing", URL, ok=(404,))
+
+
+@responses.activate
+def test_head_raises_on_rate_limit_even_when_404_is_whitelisted():
+    responses.add(responses.HEAD, URL, status=429)
+    with pytest.raises(SourceError, match="HTTP 429 probing"):
+        _head("probing", URL, ok=(404,))
+
+
+@responses.activate
+def test_head_raises_source_error_on_transport_failure():
+    responses.add(responses.HEAD, URL, body=requests.exceptions.ConnectionError("boom"))
+    with pytest.raises(SourceError, match="network error probing"):
+        _head("probing", URL)
+
+
+@responses.activate
+def test_head_reports_the_status_on_the_error():
+    """So a caller can classify the failure without parsing the message."""
+    responses.add(responses.HEAD, URL, status=503)
+    with pytest.raises(SourceError) as e:
+        _head("probing", URL)
+    assert e.value.status == 503
+
+
+@responses.activate
+def test_head_leaves_the_status_unset_for_a_transport_failure():
+    """There is no status to report, which is itself the distinction."""
+    responses.add(responses.HEAD, URL, body=requests.exceptions.ConnectionError("boom"))
+    with pytest.raises(SourceError) as e:
+        _head("probing", URL)
+    assert e.value.status is None
+
+
+# --- retry: insurance against a blip, not a throttling strategy ---------------
+
+
+@responses.activate
+def test_head_retries_a_transient_status_and_returns_the_recovered_response():
+    """One 503 in a long probe sweep should not decide the outcome."""
+    responses.add(responses.HEAD, URL, status=503)
+    responses.add(responses.HEAD, URL, status=200)
+    assert _head("probing", URL).status_code == 200
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_head_retries_a_transport_failure():
+    responses.add(responses.HEAD, URL, body=requests.exceptions.ConnectionError("boom"))
+    responses.add(responses.HEAD, URL, status=404)
+    assert _head("probing", URL, ok=(404,)).status_code == 404
+
+
+@responses.activate
+def test_head_still_raises_when_the_host_keeps_refusing():
+    """A retry does not turn a sustained outage into an answer."""
+    responses.add(responses.HEAD, URL, status=503)
+    responses.add(responses.HEAD, URL, status=503)
+    with pytest.raises(SourceError, match="HTTP 503"):
+        _head("probing", URL)
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_head_does_not_retry_a_settled_answer():
+    """A 403 is a decision, not a blip; retrying it only wastes a request."""
+    responses.add(responses.HEAD, URL, status=403)
+    with pytest.raises(SourceError, match="HTTP 403"):
+        _head("probing", URL)
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_head_does_not_retry_a_whitelisted_status():
+    responses.add(responses.HEAD, URL, status=404)
+    _head("probing", URL, ok=(404,))
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_head_backs_off_between_attempts():
+    """Retrying instantly would just hand the host two requests at once."""
+    waited = []
+    responses.add(responses.HEAD, URL, status=503)
+    responses.add(responses.HEAD, URL, status=200)
+    http.head("probing", URL, sleep=waited.append)
+    assert waited == [http._HEAD_BACKOFF]
+
+
+# --- rate-limit hints are host-scoped ----------------------------------------
+
+
+@responses.activate
+def test_a_non_github_throttle_does_not_blame_github():
+    """Naming the wrong service sends the reader chasing the wrong problem.
+
+    The --base-dir advice in the GitHub hint is doubly wrong here: no checkout
+    can stand in for what opendev publishes.
+    """
+    responses.add(responses.HEAD, URL, status=429)
+    with pytest.raises(SourceError) as e:
+        _head("probing", URL, ok=(404,))
+    assert "raw.githubusercontent.com" not in str(e.value)
+    assert "--base-dir" not in str(e.value)
+
+
+@responses.activate
+def test_a_non_github_throttle_echoes_retry_after_when_offered():
+    responses.add(responses.HEAD, URL, status=429, headers={"Retry-After": "30"})
+    with pytest.raises(SourceError, match="30s"):
+        _head("probing", URL, ok=(404,))
+
+
+@responses.activate
+def test_a_github_throttle_still_gets_the_github_hint():
+    """The existing advice is right for the host it was written about."""
+    responses.add(responses.HEAD, GH, status=429)
+    with pytest.raises(SourceError, match="raw.githubusercontent.com"):
+        _head("reading", GH)

--- a/tests/kolla_drift/test_kolla_source_ref_phase.py
+++ b/tests/kolla_drift/test_kolla_source_ref_phase.py
@@ -1,0 +1,368 @@
+from pathlib import Path
+import pytest
+import requests
+import responses
+from osism_drift import http
+from osism_drift.config import Allowlist, AllowEntry, Config, PluginCfg, Remote
+from osism_drift.http import SourceError
+from osism_drift.model import DriftEntry
+from osism_drift.drift import kolla_source_ref_phase as plugin
+
+FIXT = Path(__file__).parent / "fixtures"
+API = "https://api.github.com/repos"
+TARBALLS = "https://tarballs.opendev.org/openstack"
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_wait(monkeypatch):
+    """head() retries a transient failure; don't spend the backoff in tests."""
+    monkeypatch.setattr(http, "_HEAD_BACKOFF", 0)
+
+
+def _exists(*present):
+    """An existence stub: the (project, ref) pairs opendev publishes."""
+    have = set(present)
+    return lambda project, ref: (project, ref) in have
+
+
+def _inconclusive(kind="HTTP 503", detail="HTTP 503 probing foo"):
+    """An existence stub whose probe never settles."""
+
+    def exists(project, ref):
+        raise plugin.ProbeInconclusive(kind, detail)
+
+    return exists
+
+
+def test_flags_ref_when_a_later_phase_tarball_is_published():
+    """stable-B is still served but frozen; unmaintained-B is the live artifact."""
+    got = plugin.scan({"foo": "stable-B"}, "B", _exists(("foo", "unmaintained-B")))
+    assert got.stale == [("foo", "stable-B", "unmaintained-B")]
+    assert got.unresolved == []
+
+
+def test_silent_when_no_later_phase_is_published():
+    """The EOL case: nothing later exists, so the frozen tarball is all there is."""
+    assert plugin.scan({"foo": "stable-B"}, "B", _exists()).stale == []
+
+
+def test_silent_when_already_on_the_latest_published_phase():
+    """Configured unmaintained-B, and nothing later: correct, no drift."""
+    got = plugin.scan(
+        {"foo": "unmaintained-B"}, "B", _exists(("foo", "unmaintained-B"))
+    )
+    assert got.stale == []
+
+
+def test_does_not_probe_or_flag_the_configured_phase_itself():
+    """Only later phases matter, so the configured ref is never probed."""
+    probed = []
+
+    def exists(project, ref):
+        probed.append(ref)
+        return False
+
+    assert plugin.scan({"foo": "unmaintained-B"}, "B", exists).stale == []
+    assert probed == []
+
+
+def test_probes_only_the_phases_opendev_publishes_a_tarball_for():
+    """The -eom/-eol tags get no tarball, so probing them is wasted work.
+
+    Upstream tags both transitions -- <r>-eom entering the unmaintained phase,
+    <r>-eol on deletion -- but no tarball is built for a tag. A candidate that
+    can never resolve costs a request per project and offers a target nobody can
+    download.
+    """
+    probed = []
+
+    def exists(project, ref):
+        probed.append(ref)
+        return False
+
+    plugin.scan({"foo": "stable-B"}, "B", exists)
+    assert probed == ["unmaintained-B"]
+
+
+def test_a_release_already_moved_costs_no_probes():
+    """unmaintained is the last published phase, so nothing is left to check."""
+    probed = []
+
+    def exists(project, ref):
+        probed.append(ref)
+        return False
+
+    plugin.scan({"a": "unmaintained-B", "b": "unmaintained-B"}, "B", exists)
+    assert probed == []
+
+
+def test_later_phases_are_only_those_after_the_configured_one():
+    """The ordering the scan depends on, without the phases that have no tarball."""
+    assert plugin._later_phases("B", "stable-B") == ["unmaintained-B"]
+    assert plugin._later_phases("B", "unmaintained-B") == []
+    assert plugin._later_phases("B", "stable/4.6") == []
+
+
+def test_skips_ref_that_does_not_name_the_release():
+    """gnocchi-style independent branch naming (stable/4.6) is out of scope."""
+    got = plugin.scan(
+        {"gnocchi": "stable/4.6"}, "B", _exists(("gnocchi", "unmaintained-B"))
+    )
+    assert got.stale == []
+
+
+def test_skips_valueless_ref():
+    got = plugin.scan({"nova": None}, "B", _exists(("nova", "unmaintained-B")))
+    assert got.stale == []
+
+
+def test_preserves_hyphenated_project_names():
+    got = plugin.scan(
+        {"neutron-dynamic-routing": "stable-B"},
+        "B",
+        _exists(("neutron-dynamic-routing", "unmaintained-B")),
+    )
+    assert got.stale == [("neutron-dynamic-routing", "stable-B", "unmaintained-B")]
+
+
+# --- an unanswered probe is unknown, not clean -------------------------------
+
+
+def test_inconclusive_probe_is_reported_unresolved_not_clean():
+    """The blind spot this plugin closes: a failed probe must not read as 'no drift'."""
+    got = plugin.scan({"foo": "stable-B"}, "B", _inconclusive("HTTP 503", "boom"))
+    assert got.stale == []
+    assert got.unresolved == [("foo", "stable-B", "HTTP 503", "boom")]
+
+
+def test_inconclusive_probe_does_not_also_yield_a_stale_finding():
+    """With one candidate unknown, naming a target phase would be a guess."""
+    got = plugin.scan({"foo": "stable-B"}, "B", _inconclusive())
+    assert [p for p, *_ in got.stale] == []
+
+
+def test_one_inconclusive_project_does_not_hide_the_others():
+    """A per-project failure must not cost the whole release's findings."""
+
+    def exists(project, ref):
+        if project == "bad":
+            raise plugin.ProbeInconclusive("HTTP 503", "boom")
+        return True
+
+    got = plugin.scan({"bad": "stable-B", "good": "stable-B"}, "B", exists)
+    assert got.stale == [("good", "stable-B", "unmaintained-B")]
+    assert [p for p, *_ in got.unresolved] == ["bad"]
+
+
+def test_probe_inconclusive_is_a_source_error():
+    """So an uncaught one degrades to the ordinary abort, not a traceback."""
+    assert issubclass(plugin.ProbeInconclusive, SourceError)
+
+
+def _mock_tarball(project, ref, status):
+    responses.add(
+        responses.HEAD, f"{TARBALLS}/{project}/{project}-{ref}.tar.gz", status=status
+    )
+
+
+@responses.activate
+def test_tarball_exists_true_for_a_published_artifact():
+    _mock_tarball("nova", "unmaintained-2024.1", 200)
+    assert plugin.tarball_exists("nova", "unmaintained-2024.1") is True
+
+
+@responses.activate
+def test_tarball_exists_false_when_absent():
+    _mock_tarball("nova", "unmaintained-2024.1", 404)
+    assert plugin.tarball_exists("nova", "unmaintained-2024.1") is False
+
+
+@responses.activate
+def test_tarball_exists_raises_instead_of_reporting_absent_on_outage():
+    """An upstream 5xx must not be read as 'no later phase' and silently hide drift."""
+    _mock_tarball("nova", "unmaintained-2024.1", 503)
+    with pytest.raises(plugin.ProbeInconclusive) as e:
+        plugin.tarball_exists("nova", "unmaintained-2024.1")
+    assert e.value.kind == "HTTP 503"
+
+
+@responses.activate
+def test_tarball_exists_classifies_a_transport_failure():
+    """No status to report, but still inconclusive rather than absent."""
+    responses.add(
+        responses.HEAD,
+        f"{TARBALLS}/nova/nova-unmaintained-2024.1.tar.gz",
+        body=requests.exceptions.ConnectionError("boom"),
+    )
+    with pytest.raises(plugin.ProbeInconclusive) as e:
+        plugin.tarball_exists("nova", "unmaintained-2024.1")
+    assert e.value.kind == "network error"
+
+
+def test_declares_the_host_no_base_dir_can_serve():
+    """The driver reads this to refuse a local-only run up front."""
+    assert plugin.EXTERNAL_HOSTS == ("tarballs.opendev.org",)
+
+
+def _entry(project, release="2024.1", latest="unmaintained-2024.1"):
+    return DriftEntry(
+        plugin=plugin.NAME,
+        image=project,
+        alias=project,
+        expected=latest,
+        found=f"stable-{release}",
+        expected_src=plugin.EXPECTED_SRC,
+        found_src=f"osism/release latest/openstack-{release}.yml",
+        remediation=plugin.remediation_for(release, latest),
+    )
+
+
+def _unresolved_entry(project, release="2024.1", kind="HTTP 503"):
+    return DriftEntry(
+        plugin=plugin.NAME,
+        image=project,
+        alias=project,
+        expected=plugin.UNRESOLVED_EXPECTED,
+        found=f"stable-{release}",
+        expected_src=plugin.EXPECTED_SRC,
+        found_src=f"osism/release latest/openstack-{release}.yml",
+        summary=plugin.UNRESOLVED_SUMMARY,
+        remediation=plugin.unresolved_remediation(kind),
+    )
+
+
+def test_report_names_the_target_phase_and_the_file_to_edit():
+    """ "the later phase" is not actionable; the concrete phase must reach the report."""
+    from osism_drift import report
+
+    text = "\n".join(report.format_text([_entry("neutron")], [plugin]))
+    assert "neutron" in text
+    assert "unmaintained-2024.1" in text
+    assert "latest/openstack-2024.1.yml" in text
+
+
+def test_report_does_not_offer_a_phase_that_has_no_tarball():
+    """Naming -eol/-eom as a target sends the reader after a 404."""
+    from osism_drift import report
+
+    text = "\n".join(report.format_text([_entry("neutron")], [plugin]))
+    assert "2024.1-eol" not in text
+    assert "2024.1-eom" not in text
+
+
+def test_projects_moving_to_the_same_phase_share_one_report_block():
+    """Per-entry remediation must not embed the project, or the report fragments."""
+    from osism_drift import report
+
+    drifts = [_entry("neutron"), _entry("nova")]
+    text = "\n".join(report.format_text(drifts, [plugin]))
+    assert text.count(plugin.NAME) == 1
+    assert "neutron, nova" in text
+
+
+def test_plugin_level_remediation_describes_the_rename_without_inventing_phases():
+    """The fallback constant is used when an entry carries no override."""
+    assert "stable-<release>" in plugin.REMEDIATION
+    assert "unmaintained/<release>" in plugin.REMEDIATION
+    assert "-eol" not in plugin.REMEDIATION
+    assert "-eom" not in plugin.REMEDIATION
+
+
+def test_unresolved_report_says_unknown_rather_than_clean():
+    """An operator must not read a failed probe as a passing check."""
+    from osism_drift import report
+
+    text = "\n".join(report.format_text([_unresolved_entry("neutron")], [plugin]))
+    flowed = " ".join(text.split())  # the report wraps at 76 columns
+    assert "could not be established" in flowed
+    assert "unknown rather than confirmed current" in flowed
+    assert "HTTP 503" in flowed
+    assert "neutron" in text
+
+
+def test_unresolved_refs_failing_alike_share_one_report_block():
+    """Keying the remediation on the cause alone keeps the block from fragmenting."""
+    from osism_drift import report
+
+    drifts = [_unresolved_entry("neutron"), _unresolved_entry("nova")]
+    text = "\n".join(report.format_text(drifts, [plugin]))
+    assert text.count(plugin.NAME) == 1
+    assert "neutron, nova" in text
+
+
+def test_unresolved_and_stale_render_as_separate_blocks():
+    """They call for different actions: move the ref vs re-run the check."""
+    from osism_drift import report
+
+    text = "\n".join(
+        report.format_text([_entry("nova"), _unresolved_entry("neutron")], [plugin])
+    )
+    assert text.count(plugin.NAME) == 2
+
+
+def test_unresolved_entry_is_actionable_so_the_run_exits_nonzero():
+    """A check that could not answer is not a pass."""
+    assert _unresolved_entry("nova").severity == "actionable"
+
+
+@pytest.fixture
+def cfg():
+    return Config(
+        remote=Remote("https://raw.githubusercontent.com/", f"{API}/", "main", "osism"),
+        base_dirs=(str(FIXT),),
+        remote_fallback=True,
+        release_version="latest",
+        plugins={"kolla_source_ref_phase": PluginCfg(enabled=True)},
+        releases=("B",),
+    )
+
+
+@responses.activate
+def test_run_reports_drift_read_from_the_release_manifest(cfg):
+    """End to end over fixtures/release/latest/openstack-B.yml (all on stable-B)."""
+    for project in ("foo", "bar", "multi-word"):
+        _mock_tarball(project, "unmaintained-B", 200 if project == "foo" else 404)
+
+    drifts = plugin.run(cfg, Allowlist(()))
+
+    assert len(drifts) == 1
+    d = drifts[0]
+    assert (d.plugin, d.image, d.expected, d.found) == (
+        "kolla_source_ref_phase",
+        "foo",
+        "unmaintained-B",
+        "stable-B",
+    )
+    assert d.found_src == "osism/release latest/openstack-B.yml"
+    assert "tarballs.opendev.org" in d.expected_src
+
+
+@responses.activate
+def test_run_reports_an_unverified_ref_when_the_probe_fails(cfg):
+    """One project's outage becomes one unverified finding, not a lost run."""
+    _mock_tarball("foo", "unmaintained-B", 200)
+    for project in ("bar", "multi-word"):
+        _mock_tarball(project, "unmaintained-B", 503)
+
+    drifts = plugin.run(cfg, Allowlist(()))
+
+    by_image = {d.image: d for d in drifts}
+    assert by_image["foo"].expected == "unmaintained-B"
+    assert by_image["bar"].expected == plugin.UNRESOLVED_EXPECTED
+    assert "HTTP 503" in by_image["bar"].remediation
+
+
+@responses.activate
+def test_run_allowlists_an_unverified_ref_for_a_pinned_project(cfg):
+    """A deliberately pinned project's phase does not matter, probe or no probe."""
+    for project in ("foo", "bar", "multi-word"):
+        _mock_tarball(project, "unmaintained-B", 503)
+    allowlist = Allowlist(
+        (AllowEntry(plugin=plugin.NAME, image="bar", reason="pinned on purpose"),)
+    )
+
+    drifts = plugin.run(cfg, allowlist)
+
+    by_image = {d.image: d for d in drifts}
+    assert by_image["bar"].allowlisted is True
+    assert by_image["foo"].allowlisted is False

--- a/tests/kolla_drift/test_plugin_registry.py
+++ b/tests/kolla_drift/test_plugin_registry.py
@@ -73,6 +73,7 @@ def test_kolla_mirror_verbatim_plugin_registered():
 
 def test_plugins_in_lifecycle_order():
     assert [p.NAME for p in KOLLA_PLUGINS] == [
+        "kolla_source_ref_phase",
         "kolla_enablement_orphan",
         "kolla_groupvars_missing",
         "kolla_mirror_verbatim",

--- a/tests/kolla_drift/test_source.py
+++ b/tests/kolla_drift/test_source.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 import responses
 from osism_drift.source import read, SourceError, read_optional, list_dir
-from osism_drift.config import load_config, SourceCfg
+from osism_drift.config import load_config, Remote, SourceCfg
 
 
 def _targz(files, *, top="osism-release-abc123", extra_members=None):
@@ -961,6 +961,51 @@ def test_plain_403_is_not_mistaken_for_rate_limiting(tmp_path):
     msg = str(exc.value)
     assert "HTTP 403" in msg
     assert "rate limit" not in msg
+
+
+@responses.activate
+def test_non_github_host_does_not_get_the_github_hint(tmp_path, monkeypatch):
+    # A github_raw override pointing somewhere other than GitHub -- the same case
+    # _auth_headers keeps a token from leaking into. A markerless 429 from that
+    # host is not raw.githubusercontent.com CDN throttling, so naming it would
+    # send the reader chasing the wrong service, and --base-dir advice that is
+    # about GitHub's per-IP limit need not apply there at all.
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    responses.add(
+        responses.GET,
+        "https://mirror.example.net/osism/release/main/latest/base.yml",
+        status=429,
+    )
+    cfg = dataclasses.replace(
+        _cfg(tmp_path),
+        remote=Remote("https://mirror.example.net/", "https://api/", "main", "osism"),
+    )
+    with pytest.raises(SourceError) as exc:
+        read("release", "latest/base.yml", cfg)
+    msg = str(exc.value)
+    assert "HTTP 429" in msg
+    assert "raw.githubusercontent.com" not in msg
+    assert "--base-dir" not in msg
+
+
+@responses.activate
+def test_non_github_host_echoes_retry_after_when_offered(tmp_path, monkeypatch):
+    # The one piece of advice that is not GitHub-specific: the host's own ask.
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    responses.add(
+        responses.GET,
+        "https://mirror.example.net/osism/release/main/latest/base.yml",
+        status=429,
+        headers={"Retry-After": "30"},
+    )
+    cfg = dataclasses.replace(
+        _cfg(tmp_path),
+        remote=Remote("https://mirror.example.net/", "https://api/", "main", "osism"),
+    )
+    with pytest.raises(SourceError, match="30s"):
+        read("release", "latest/base.yml", cfg)
 
 
 def test_auth_headers_adds_bearer_for_github_host(monkeypatch):


### PR DESCRIPTION
Detects the silent failure that left OSISM's 2024.1 images on October 2025
sources for nine months.

Upstream renames `stable/<release>` to `unmaintained/<release>` when a release
enters the unmaintained phase, and deletes the branch at EOL.
`tarballs.opendev.org` keeps serving the artifact for a retired branch name but
stops regenerating it, so a build that still asks for
`<project>-stable-<release>.tar.gz` keeps succeeding while its sources sit
frozen at the moment of the rename. Nothing fails, so nothing prompts a fix —
which is exactly what happened to 2024.1, and only surfaced when a fix for
CVE-2026-55707 failed to appear in a freshly rebuilt image.

- https://osism.tech/docs/appendix/security/ossa-2026-032/
- https://bugs.launchpad.net/neutron/+bug/2152113

That instance is fixed (osism/release#2640, osism/container-images-kolla#762).
This adds the check that would have caught it on day one, and will catch 2025.1
when it transitions.

## The three commits

Please **rebase-merge** rather than squash: the first commit is an independent
fix to pre-existing code and the third a general driver capability, and both
read better in `main`'s history on their own.

1. **`http: scope rate-limit hints to the host`** — a pre-existing bug, fixable
   and reviewable on its own. `_rate_limit_hint()` describes GitHub's rate
   limits but never checked that the response came from GitHub, so any
   markerless 429 was reported as `raw.githubusercontent.com` CDN throttling
   with advice built around that host. Reachable today through a non-GitHub
   `github_raw`/`github_api` override — the same case `_auth_headers()` already
   guards a token against. Behaviour for GitHub hosts is unchanged.
2. **`Add drift check for stale OpenStack source refs`** — the plugin, plus the
   transport and parsing it needs.
3. **`Refuse a local-only run that needs the network`** — `--base-dir` without
   `--remote-fallback` is a local-only run, and `source._resolve()` enforces it
   by erroring rather than fetching. This plugin asks what upstream publishes
   right now, which no checkout records, so it would reach the network
   regardless of the mode requested. A plugin may now declare `EXTERNAL_HOSTS`
   and the driver refuses such a run up front, listing every offending plugin at
   once. Optional and read with `getattr`, so no other plugin changes.

## Design notes worth a look

**Artifact-driven, not branch-driven.** The question is which tarball the build
consumes, so probing the published set answers it directly. It also avoids a
blocker: `release_to_ref` would need an upstream owner configured per project,
and `sources` maps only `kolla` and `kolla_ansible` (default owner `osism`), so
a branch probe would 404 on all 21 projects.

**Only two phases are probed, because only two are published.** Upstream marks
both transitions with a tag — `<release>-eom` when the stable branch becomes
unmaintained, `<release>-eol` when the unmaintained branch is deleted — and
those tags invite the assumption that they are further phases to move to. They
are not: opendev builds an artifact per *branch*, so no tarball exists for
either tag. Verified 404 for every `<release>-eol` and `<release>-eom` URL
checked across nova, aodh, keystone, cinder, glance and requirements, over
2023.1, 2023.2, 2024.1, 2024.2, victoria, wallaby and zed — while a release-tag
tarball such as `nova-30.0.0.tar.gz` does resolve. The tags also run the
opposite way round from what the names suggest: nova carries `2024.1-eom` and
`2023.1-eom` while `unmaintained/2024.1` and `unmaintained/2023.1` are still
live branches, and `2023.2-eol`/`2024.2-eol` sit on series whose branch is
already deleted. A full run is 68 probes, and a release already moved to
`unmaintained` costs none.

**One HEAD per candidate, not the index listing.** My first version read the
per-project index — fewer requests, one per project covers all releases — but
those listings are large (nova's is ~1.4 MB with 10k entries) and timed out
intermittently in live runs, first on keystone at 30s then nova at 90s. A HEAD
is a few hundred bytes.

**An unanswered probe is unknown, not clean.** Reading an outage or a throttled
response as "no later phase published" would report no drift and silently
reinstate the blind spot this check exists to close, so anything but a 200 or a
404 raises `ProbeInconclusive`. That guard sits on the *finding*, not on the
run: the driver wraps its whole plugin loop in one handler, so raising would
discard every other plugin's findings over one upstream hiccup. `scan()` catches
it per project and reports the ref as unverified — phase unknown rather than
confirmed current, in its own report block, actionable so the run still exits
non-zero. `head()` additionally retries a transport failure or a transient
status once with a backoff; measured first, 110 sequential HEADs against opendev
took 47s with no 429 and no 5xx and no rate-limit headers in the responses
(plain Apache, no CDN), so a blip is the failure mode there rather than
throttling.

**Silence is not always a clean bill of health.** For a release with no later
phase published — 2024.2, which is EOL — the frozen `stable` tarball is the only
option and nothing is flagged. That is correct behaviour, but it means silence
there says "no better ref exists", not "sources are current".

## Verification

Replayed against the pre-fix manifest with live probes: **21 of 22 refs flagged
in 9s**, `gnocchi` correctly skipped because `stable/4.6` does not follow the
release lifecycle. Against the current tree the plugin reports nothing, and
2024.2 and 2025.x stay silent. A local-only run exits 2 before any probe; a full
live run takes 30s.

Each commit was checked out into a clean worktree and verified there — **341,
392 and 398 tests passing** respectively, `flake8` and `black` clean at every
step.

## Not covered

The requirements ref in `container-images-kolla` `scripts/002-generate.sh` is
hardcoded rather than read from the manifest, so this plugin cannot see it.
Detecting that would mean parsing shell in another repo. The retirement guide's
checklist is the control there:

- osism/osism.github.io#1048

Two related refs are also outside what this checks, both currently still on
`stable-`: `openstackclient/Containerfile` in `container-images` (a no-op today —
that matrix builds only 2025.1/2025.2/2026.1) and the IPA artifacts in
`container-image-kolla-ansible`, where `ipa-centos9-unmaintained-2024.1.initramfs`
exists and is fresh while the `stable-2024.1` one froze on 2025-10-09.
