### PR TITLE
Read the kolla defaults mirror as an 001-* layer

### DIFF
--- a/src/osism_drift/drift/kolla_groupvars_missing.py
+++ b/src/osism_drift/drift/kolla_groupvars_missing.py
@@ -25,7 +25,7 @@ role-defaults/tasks/tests, matching kolla_enablement_orphan; keys are compared
 verbatim (an Ansible var name is an exact identifier).
 
 A missing key is supplied, not judged: OSISM mirrors the full upstream union, so a
-missing var is added to osism/defaults — to 001-kolla-defaults.yml if upstream
+missing var is added to osism/defaults — to all/001-*.yml if upstream
 defines it at the newest supported release, else to a self-retiring
 010-<last-release>.yml carrying it for the older releases that still define it
 (deleted when that release ages out). OSISM does NOT decide "the service is not
@@ -56,8 +56,8 @@ SUMMARY = (
     "undefined in the deploy var context and aborts any role task that uses it:"
 )
 REMEDIATION = (
-    "mirror the missing var: into all/001-kolla-defaults.yml if upstream defines it "
-    "at the newest supported release, else into a self-retiring "
+    "mirror the missing var: into the all/001-*.yml mirror layer if upstream defines "
+    "it at the newest supported release, else into a self-retiring "
     "all/010-<last-release>.yml (labelled for the newest supported release that "
     "still defines it, deleted when it ages out). Allowlist only if OSISM already "
     "supplies the var another way the detector cannot see."
@@ -92,13 +92,13 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
         dest = enablement.groupvars_home(key, newest, up_keys, dropped)
         if dest is not None:
             path, _ = dest
-            if path == "all/001-kolla-defaults.yml":
+            if path == enablement.MIRROR_LAYER:
                 per_summary = (
                     f"{{n}} upstream kolla-ansible group_vars defined at {newest} "
                     "that OSISM never mirrored:"
                 )
                 per_remediation = (
-                    f"mirror each into all/001-kolla-defaults.yml "
+                    f"mirror each into the {enablement.MIRROR_LAYER} mirror layer "
                     f"(upstream defines it at newest release {newest})."
                 )
             else:

--- a/src/osism_drift/drift/kolla_mirror_verbatim.py
+++ b/src/osism_drift/drift/kolla_mirror_verbatim.py
@@ -1,12 +1,12 @@
-"""kolla_mirror_verbatim: 001-kolla-defaults.yml must mirror upstream-newest.
+"""kolla_mirror_verbatim: all/001-* must mirror upstream-newest.
 
-osism/defaults all/001-kolla-defaults.yml is meant to be a VERBATIM copy of
-upstream kolla-ansible group_vars/all at the newest supported release; every
-OSISM opinion lives in a 099-* file. Nothing enforced that, so 001 drifts
-(it currently carries keys upstream dropped in 2025.2). This is the enforcement
-arm of Convention X: it flags every way 001 deviates from upstream-newest and,
-for each deviation, prints the exact destination to move the key to. It never
-tells anyone to allowlist a group_var (Convention X forbids it).
+osism/defaults all/001-*.yml files together form a VERBATIM copy of upstream
+kolla-ansible group_vars/all at the newest supported release; every OSISM opinion
+lives in a 099-* file. Nothing enforced that, so 001 drifts (it currently carries
+keys upstream dropped in 2025.2). This is the enforcement arm of Convention X: it
+flags every way the 001 layer deviates from upstream-newest and, for each deviation,
+prints the exact destination to move the key to. It never tells anyone to allowlist
+a group_var (Convention X forbids it).
 
 Companion to kolla_groupvars_missing, which only proves the upstream union is
 supplied SOMEWHERE (it cannot see values or which file a key sits in). This
@@ -18,12 +18,12 @@ from osism_drift.model import DriftEntry
 
 NAME = "kolla_mirror_verbatim"
 DESCRIPTION = (
-    "Flag any all/001-kolla-defaults.yml key or value that differs from upstream "
-    "kolla-ansible group_vars/all at the newest supported release, so 001 stays a "
-    "verbatim mirror and OSISM opinions live in 099-*."
+    "Flag any all/001-*.yml key or value that differs from upstream "
+    "kolla-ansible group_vars/all at the newest supported release, so the 001 layer "
+    "stays a verbatim mirror and OSISM opinions live in 099-*."
 )
 INPUT_FILES = [
-    ("defaults", "all/001-kolla-defaults.yml"),
+    ("defaults", "all/001-*.yml"),
     ("kolla_ansible", "ansible/group_vars/all[.yml|/*.yml] (newest resolved ref)"),
 ]
 # Module-level fallbacks (the registry test requires SUMMARY to contain "{n}").
@@ -59,7 +59,7 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
     ref = source.release_to_ref("kolla_ansible", newest, config)
 
     expected_src = f"openstack/kolla-ansible group_vars/all @ {ref}"
-    found_src = "osism/defaults all/001-kolla-defaults.yml"
+    found_src = "osism/defaults all/001-*.yml"
 
     def _mk(key, *, expected, found, summary, remediation):
         return DriftEntry(
@@ -91,7 +91,7 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
                 ),
                 remediation=(
                     f"mirror the upstream {newest} key and value verbatim into "
-                    "all/001-kolla-defaults.yml."
+                    "all/001-*.yml."
                 ),
             )
         )
@@ -122,7 +122,7 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
         if k in non001:
             summary = "{n} key(s) in 001 that another OSISM layer already supplies:"
             remediation = (
-                "delete each from all/001-kolla-defaults.yml — 001 mirrors upstream "
+                "delete each from all/001-*.yml — the 001 layer mirrors upstream "
                 f"{newest}, which does not define it, and 099-*/overlay/versions "
                 "already supplies it."
             )

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -296,28 +296,54 @@ def upstream_groupvars_values(release, config) -> dict:
     return groupvars_values(_upstream_groupvars_bodies(release, config))
 
 
-_MIRROR_FILE = "all/001-kolla-defaults.yml"
+_MIRROR_PREFIX = "001-"
+
+# User-facing label for the mirror layer. One definition, so the plugin that
+# routes keys into the layer and the plugin that reports on it cannot disagree
+# about what to call it.
+MIRROR_LAYER = f"{_OSISM_DEFAULTS_DIR}/{_MIRROR_PREFIX}*.yml"
+
+
+def _mirror_filenames(config) -> list[str]:
+    """Sorted all/ filenames forming the 001 mirror layer.
+
+    Sorted because the caller merges them: all/ is loaded in lexical filename
+    order with later files winning, and the GitHub contents API makes no
+    ordering promise. Upstream itself relies on this (it defines the same
+    database_* keys in both common.yml and database.yml, and database.yml wins),
+    so an unsorted listing would silently pick the wrong value.
+    """
+    return sorted(
+        fn
+        for fn in source.list_dir("defaults", _OSISM_DEFAULTS_DIR, config)
+        if fn.startswith(_MIRROR_PREFIX) and fn.endswith(".yml")
+    )
 
 
 def osism_mirror_values(config) -> dict:
-    """{key: parsed value} of osism/defaults all/001-kolla-defaults.yml ONLY.
+    """{key: parsed value} of the osism/defaults all/001-* mirror layer ONLY.
 
-    Scoped to the single mirror file (not the all/*.yml union) because
+    Scoped to the mirror layer (not the all/*.yml union) because
     kolla_mirror_verbatim enforces 001 purity specifically: a key OSISM supplies
-    from 099-* must not count as "in the mirror"."""
-    return groupvars_values([source.read("defaults", _MIRROR_FILE, config)])
+    from 099-* must not count as "in the mirror". A layer rather than one file so
+    the mirror can be split per upstream service without touching this code."""
+    return groupvars_values(
+        source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
+        for fn in _mirror_filenames(config)
+    )
 
 
 def osism_supply_excluding_mirror(config) -> set:
-    """Top-level keys OSISM supplies from every layer EXCEPT 001 — the other
-    all/*.yml files + the rendered versions.yml.j2 + the per-release overlays.
+    """Top-level keys OSISM supplies from every layer EXCEPT the 001-* mirror
+    layer — the other all/*.yml files + the rendered versions.yml.j2 + the
+    per-release overlays.
 
     Same three-path logic as osism_groupvars_keys, minus the 001 file: lets
     kolla_mirror_verbatim tell "a 001-only key that another layer already
     supplies" (delete from 001) from "a 001-only key nothing else supplies"."""
     keys = set()
     for fn in sorted(source.list_dir("defaults", _OSISM_DEFAULTS_DIR, config)):
-        if fn.endswith(".yml") and f"{_OSISM_DEFAULTS_DIR}/{fn}" != _MIRROR_FILE:
+        if fn.endswith(".yml") and not fn.startswith(_MIRROR_PREFIX):
             keys |= top_level_keys(
                 source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
             )

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -357,13 +357,13 @@ def osism_supply_excluding_mirror(config) -> set:
 def groupvars_home(key, newest, newest_keys, dropped_map):
     """Return (path, note) for where a group_var key belongs, or None.
 
-    key in newest_keys  -> ("all/001-kolla-defaults.yml", note with newest)
+    key in newest_keys  -> (MIRROR_LAYER, note with newest)
     else key in dropped -> (f"all/010-{L}.yml", note with L)    if L
     else                -> None  (caller falls back to static text)
 
     Pure: takes precomputed sets/maps, no I/O."""
     if key in newest_keys:
-        return ("all/001-kolla-defaults.yml", f"upstream defines it at {newest}")
+        return (MIRROR_LAYER, f"upstream defines it at {newest}")
     L = dropped_map.get(key)
     if L:
         return (f"all/010-{L}.yml", f"upstream dropped by {newest}; last in {L}")

--- a/src/release-notes.py
+++ b/src/release-notes.py
@@ -100,7 +100,6 @@ KOLLA_IMAGES_REPO = "osism/container-images-kolla"
 # files are applied in lexicographic order, later files win.
 OSISM_DEFAULTS_REPO = "osism/defaults"
 OSISM_KOLLA_DEFAULTS_FILES = [
-    "all/001-kolla-defaults.yml",
     "all/099-kolla.yml",
 ]
 
@@ -382,6 +381,47 @@ def list_patch_files(repo, image_version, openstack_version):
     )
 
 
+def list_mirror_layer_files(repo, version):
+    """List the all/001-* kolla defaults mirror layer of `repo` at `version`.
+
+    The layer may be split per upstream service, so list it from the tree rather
+    than hardcoding names.
+    Sorted, because all/ is merged in lexical filename order and later files win.
+
+    Returns None if the listing fails or is truncated, and [] only when the
+    listing succeeded and found no 001-* file. The caller must treat None as
+    fatal: this section is labelled "the effective kolla defaults" and every
+    configuration recommendation is checked against it, so publishing it without
+    the mirror layer is worse than not publishing it at all.
+    """
+    url = f"https://api.github.com/repos/{repo}/git/trees/{version}?recursive=1"
+    try:
+        response = requests.get(url, headers=github_headers(), timeout=30)
+    except requests.RequestException as e:
+        warn(f"Fetching {url} failed: {e}")
+        return None
+    if response.status_code != 200:
+        warn(
+            f"Could not list the tree of {repo} at {version} "
+            f"(HTTP {response.status_code})"
+        )
+        return None
+    data = response.json()
+    if data.get("truncated"):
+        # Not the partial tree: a short layer would render a plausible but
+        # incomplete "effective defaults" section. None, not [], so the caller
+        # drops the whole section rather than publishing it without the layer.
+        warn(f"Tree listing of {repo} at {version} is truncated")
+        return None
+    return sorted(
+        entry["path"]
+        for entry in data.get("tree", [])
+        if entry.get("type") == "blob"
+        and entry["path"].startswith("all/001-")
+        and entry["path"].endswith(".yml")
+    )
+
+
 def downstream_patch_lines(repo, old, old_release, new, new_release):
     """Markdown lines for the downstream patch changes of an image.
 
@@ -533,12 +573,21 @@ def osism_kolla_defaults_section(previous, current):
         f"The effective kolla defaults of this release ({OSISM_DEFAULTS_REPO} "
         f"{version}). They override the upstream kolla-ansible defaults; "
         "within this list, later files override earlier ones "
-        "(all/099-kolla.yml wins over all/001-kolla-defaults.yml). Check "
+        "(all/099-kolla.yml wins over the all/001-*.yml mirror layer). Check "
         "every configuration recommendation against these values.",
         "",
     ]
+    layer = list_mirror_layer_files(OSISM_DEFAULTS_REPO, version)
+    if layer is None:
+        warn(
+            "Could not list the all/001-* mirror layer; omitting the OSISM kolla "
+            "defaults section rather than publishing it without the layer"
+        )
+        return None
+    if not layer:
+        warn(f"No all/001-* mirror layer found in {OSISM_DEFAULTS_REPO} at {version}")
     found = False
-    for path in OSISM_KOLLA_DEFAULTS_FILES:
+    for path in layer + OSISM_KOLLA_DEFAULTS_FILES:
         info(f"Fetching {path} of {OSISM_DEFAULTS_REPO} at {version}...")
         url = (
             f"https://raw.githubusercontent.com/{OSISM_DEFAULTS_REPO}/"
@@ -547,11 +596,15 @@ def osism_kolla_defaults_section(previous, current):
         try:
             response = requests.get(url, timeout=30)
         except requests.RequestException as e:
-            warn(f"Fetching {url} failed: {e}")
-            continue
+            # Fatal, not skippable: a section missing one of the files it claims
+            # to list is indistinguishable from a complete one to a reader.
+            warn(f"Fetching {url} failed: {e}; omitting the section")
+            return None
         if response.status_code != 200:
-            warn(f"Could not fetch {url} (HTTP {response.status_code})")
-            continue
+            warn(
+                f"Could not fetch {url} (HTTP {response.status_code}); omitting the section"
+            )
+            return None
         found = True
         out.append(f"### {path}")
         out.append("")

--- a/tests/kolla_drift/test_enablement.py
+++ b/tests/kolla_drift/test_enablement.py
@@ -365,7 +365,7 @@ def _mock_roles(ref, roles):
 
 def test_groupvars_home_in_newest_keys():
     path, note = enablement.groupvars_home("k", "2025.2", {"k"}, {})
-    assert path == "all/001-kolla-defaults.yml"
+    assert path == enablement.MIRROR_LAYER
     assert "2025.2" in note
 
 
@@ -378,7 +378,7 @@ def test_groupvars_home_dropped_only():
 def test_groupvars_home_newest_wins_over_dropped():
     # key in both newest_keys and dropped_map: newest takes priority -> 001
     path, _ = enablement.groupvars_home("k", "2025.2", {"k"}, {"k": "2024.1"})
-    assert path == "all/001-kolla-defaults.yml"
+    assert path == enablement.MIRROR_LAYER
 
 
 def test_groupvars_home_neither_returns_none():

--- a/tests/kolla_drift/test_enablement_values.py
+++ b/tests/kolla_drift/test_enablement_values.py
@@ -5,6 +5,28 @@ API = "https://api.github.com/repos"
 RAW = "https://raw.githubusercontent.com"
 
 
+def _write_defaults(tmp_path, files):
+    dall = tmp_path / "defaults" / "all"
+    dall.mkdir(parents=True)
+    for name, text in files.items():
+        (dall / name).write_text(text)
+    vt = tmp_path / "container-image-kolla-ansible" / "files" / "src" / "templates"
+    vt.mkdir(parents=True)
+    (vt / "versions.yml.j2").write_text("")
+
+
+def _cfg(tmp_path):
+    return Config(
+        remote=Remote(f"{RAW}/", f"{API}/", "main", "osism"),
+        base_dirs=(str(tmp_path),),
+        remote_fallback=False,
+        release_version="latest",
+        plugins={},
+        sources={},
+        releases=("A",),
+    )
+
+
 def test_groupvars_values_merges_and_parses():
     # Two bodies; the later one wins for the overlapping key, values are parsed
     # (int stays int, string stays string) — a strict mirror needs real types.
@@ -32,3 +54,34 @@ def test_osism_mirror_values_reads_only_001(tmp_path):
     )
     # Only 001 is read, values parsed; the 099 key is absent.
     assert enablement.osism_mirror_values(cfg) == {"k": 5000, "name": "v"}
+
+
+def test_mirror_values_merges_the_whole_001_layer(tmp_path):
+    # Two mirror files: the later one wins, matching Ansible's lexical merge.
+    _write_defaults(
+        tmp_path,
+        {
+            "001-common.yml": "shared: from_common\nonly_common: 1\n",
+            "001-database.yml": "shared: from_database\n",
+            "099-kolla.yml": "osism_opinion: 1\n",
+        },
+    )
+    values = enablement.osism_mirror_values(_cfg(tmp_path))
+    assert values["shared"] == "from_database"  # 001-database sorts last
+    assert values["only_common"] == 1
+    assert "osism_opinion" not in values  # 099 is not in the layer
+
+
+def test_supply_excluding_mirror_excludes_every_layer_file(tmp_path):
+    _write_defaults(
+        tmp_path,
+        {
+            "001-common.yml": "in_layer: 1\n",
+            "001-database.yml": "also_in_layer: 1\n",
+            "099-kolla.yml": "outside_layer: 1\n",
+        },
+    )
+    keys = enablement.osism_supply_excluding_mirror(_cfg(tmp_path))
+    assert "outside_layer" in keys
+    assert "in_layer" not in keys
+    assert "also_in_layer" not in keys

--- a/tests/kolla_drift/test_kolla_groupvars_missing.py
+++ b/tests/kolla_drift/test_kolla_groupvars_missing.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from osism_drift import enablement
 from osism_drift.config import (
     Config,
     Remote,
@@ -184,7 +185,7 @@ def test_missing_key_at_newest_routes_to_001(tmp_path):
     _mock_release("stable/B", {"other", "missing_var"})
     drifts = plugin.run(_cfg(tmp_path), Allowlist(()))
     entry = next(d for d in drifts if d.image == "missing_var")
-    assert "all/001-kolla-defaults.yml" in entry.remediation
+    assert enablement.MIRROR_LAYER in entry.remediation
 
 
 @responses.activate

--- a/tests/kolla_drift/test_kolla_mirror_verbatim.py
+++ b/tests/kolla_drift/test_kolla_mirror_verbatim.py
@@ -198,3 +198,35 @@ def test_empty_release_range_raises(tmp_path):
     (tmp_path / "release" / "latest").mkdir(parents=True)  # empty -> empty range
     with pytest.raises(SourceError, match="empty supported release range"):
         plugin.run(_cfg(tmp_path, releases=()), Allowlist(()))
+
+
+@responses.activate
+def test_layer_split_across_files_is_a_clean_mirror(tmp_path):
+    # The mirror spread over two 001-* files, together matching upstream exactly,
+    # must produce no drift — the check sees the layer, not a single file.
+    _write_defaults(
+        tmp_path,
+        {
+            "001-common.yml": _mirror({"foo": 1}),
+            "001-database.yml": _mirror({"bar": "two"}),
+        },
+    )
+    _mock_release("stable/A", {"foo": 1, "bar": "two"})
+    _mock_release("stable/B", {"foo": 1, "bar": "two"})
+    assert plugin.run(_cfg(tmp_path), Allowlist(())) == []
+
+
+@responses.activate
+def test_layer_later_file_wins_on_duplicate_key(tmp_path):
+    # Upstream itself defines some keys twice across files and the lexically last
+    # one wins; the layer must resolve duplicates the same way Ansible does.
+    _write_defaults(
+        tmp_path,
+        {
+            "001-common.yml": _mirror({"dup": "loser"}),
+            "001-database.yml": _mirror({"dup": "winner"}),
+        },
+    )
+    _mock_release("stable/A", {"dup": "winner"})
+    _mock_release("stable/B", {"dup": "winner"})
+    assert plugin.run(_cfg(tmp_path), Allowlist(())) == []

--- a/tests/test_release_notes_defaults.py
+++ b/tests/test_release_notes_defaults.py
@@ -1,0 +1,202 @@
+import importlib.util
+import pathlib
+
+import requests
+import responses
+
+# release-notes.py is hyphenated -> not importable by name; load it by path.
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "release-notes.py"
+_spec = importlib.util.spec_from_file_location("release_notes", _SRC)
+rn = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rn)
+
+TREES = "https://api.github.com/repos/osism/defaults/git/trees/v1.2.3?recursive=1"
+
+
+def _tree(*paths, truncated=False):
+    return {
+        "truncated": truncated,
+        "tree": [{"path": p, "type": "blob"} for p in paths],
+    }
+
+
+@responses.activate
+def test_layer_is_sorted_and_filtered():
+    responses.add(
+        responses.GET,
+        TREES,
+        json=_tree(
+            "all/001-nova.yml",
+            "all/001-common.yml",
+            "all/099-kolla.yml",  # not in the layer
+            "all/001-notes.md",  # not a .yml
+            "all/010-2025.1.yml",  # different layer
+        ),
+        status=200,
+    )
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") == [
+        "all/001-common.yml",
+        "all/001-nova.yml",
+    ]
+
+
+@responses.activate
+def test_layer_omits_directories_and_keeps_only_blobs():
+    responses.add(
+        responses.GET,
+        TREES,
+        json={
+            "truncated": False,
+            "tree": [
+                {"path": "all/001-nova.yml", "type": "blob"},
+                {"path": "all/001-sub", "type": "tree"},
+            ],
+        },
+        status=200,
+    )
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") == [
+        "all/001-nova.yml"
+    ]
+
+
+@responses.activate
+def test_layer_none_on_http_error():
+    responses.add(responses.GET, TREES, status=404)
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") is None
+
+
+@responses.activate
+def test_layer_none_on_truncated_tree():
+    # A partial layer would render a plausible but incomplete defaults section.
+    responses.add(
+        responses.GET,
+        TREES,
+        json=_tree("all/001-nova.yml", truncated=True),
+        status=200,
+    )
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") is None
+
+
+@responses.activate
+def test_layer_none_on_request_exception():
+    # Must be a requests.RequestException subclass: list_mirror_layer_files
+    # catches that, and a plain Exception would escape the handler and error
+    # the test instead of exercising the degrade path.
+    responses.add(responses.GET, TREES, body=requests.ConnectionError("boom"))
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") is None
+
+
+@responses.activate
+def test_section_fetches_the_layer_before_099_and_names_the_layer_in_prose():
+    # The real ordering guarantee: all/ merges lexically and 099-kolla.yml wins
+    # over the layer, so the section must emit the layer files first. Asserting the
+    # constant alone would not prove the fetch order, and would not cover the
+    # prose that used to name the deleted monolith.
+    #
+    # previous/current are base.yml version maps keyed by (section, name); they
+    # must differ on one of the three keys the relevance gate checks, or the
+    # function returns None before fetching anything.
+    previous = {("", "defaults"): "v1.2.2"}
+    current = {("", "defaults"): "v1.2.3"}
+
+    responses.add(
+        responses.GET,
+        TREES,
+        json=_tree("all/001-nova.yml", "all/001-common.yml"),
+        status=200,
+    )
+    for path, body in (
+        ("all/001-common.yml", "shared: from_common\n"),
+        ("all/001-nova.yml", "nova_api_port: 8774\n"),
+        ("all/099-kolla.yml", 'enable_cinder: "yes"\n'),
+    ):
+        responses.add(
+            responses.GET,
+            f"https://raw.githubusercontent.com/osism/defaults/v1.2.3/{path}",
+            body=body,
+            status=200,
+        )
+
+    section = rn.osism_kolla_defaults_section(previous, current)
+    assert section is not None
+    headers = [ln for ln in section.splitlines() if ln.startswith("### ")]
+    assert headers == [
+        "### all/001-common.yml",
+        "### all/001-nova.yml",
+        "### all/099-kolla.yml",
+    ]
+    assert "all/001-*.yml mirror layer" in section
+    assert "001-kolla-defaults" not in section
+
+
+@responses.activate
+def test_layer_empty_list_when_listing_succeeds_with_no_matches():
+    # [] and None must stay distinguishable: this is a truthful empty answer.
+    responses.add(responses.GET, TREES, json=_tree("all/099-kolla.yml"), status=200)
+    assert rn.list_mirror_layer_files("osism/defaults", "v1.2.3") == []
+
+
+@responses.activate
+def test_section_is_none_when_the_listing_fails_even_if_099_would_fetch():
+    # The whole point of failing closed: 099 alone must not produce a section
+    # labelled "the effective kolla defaults".
+    responses.add(responses.GET, TREES, status=404)
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/osism/defaults/v1.2.3/all/099-kolla.yml",
+        body='enable_cinder: "yes"\n',
+        status=200,
+    )
+    assert (
+        rn.osism_kolla_defaults_section(
+            {("", "defaults"): "v1.2.2"}, {("", "defaults"): "v1.2.3"}
+        )
+        is None
+    )
+
+
+@responses.activate
+def test_section_is_none_when_the_listing_is_truncated():
+    responses.add(
+        responses.GET, TREES, json=_tree("all/001-nova.yml", truncated=True), status=200
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/osism/defaults/v1.2.3/all/099-kolla.yml",
+        body='enable_cinder: "yes"\n',
+        status=200,
+    )
+    assert (
+        rn.osism_kolla_defaults_section(
+            {("", "defaults"): "v1.2.2"}, {("", "defaults"): "v1.2.3"}
+        )
+        is None
+    )
+
+
+@responses.activate
+def test_section_is_none_when_one_mirror_file_fails_to_fetch():
+    # A section missing one of the files it lists reads as complete.
+    responses.add(
+        responses.GET,
+        TREES,
+        json=_tree("all/001-common.yml", "all/001-nova.yml"),
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/osism/defaults/v1.2.3/all/001-common.yml",
+        body="shared: from_common\n",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/osism/defaults/v1.2.3/all/001-nova.yml",
+        status=500,
+    )
+    assert (
+        rn.osism_kolla_defaults_section(
+            {("", "defaults"): "v1.2.2"}, {("", "defaults"): "v1.2.3"}
+        )
+        is None
+    )


### PR DESCRIPTION
Teaches the drift checks to read the `osism/defaults` kolla mirror as a layer of
`all/001-*.yml` files rather than the single hardcoded `all/001-kolla-defaults.yml`.

Upstream kolla-ansible split its monolithic `group_vars/all.yml` into ~56
per-service files in the 2025.2 cycle; `osism/defaults` is about to follow. This
lands first so that nothing breaks when it does.

- `enablement.py` hardcoded `all/001-kolla-defaults.yml` in two readers
  (`osism_mirror_values`, `osism_supply_excluding_mirror`); both now match on the
  `001-` prefix over the `all/` listing. The listing is sorted, which is
  load-bearing rather than tidy: the caller merges the files with later ones
  winning, mirroring how Ansible loads a `group_vars` directory, and the GitHub
  contents API promises no ordering. Upstream depends on that precedence — it
  defines the same seven `database_*` keys in both `common.yml` and
  `database.yml`, and `database.yml` wins by sorting later — so an unsorted
  listing would silently take the losing value.
- Check output names the layer instead of one filename, from a single
  `MIRROR_LAYER` constant, so the plugin that routes keys into the layer and the
  plugin that reports on it cannot disagree about what to call it.
- Covers a second consumer outside the drift package: `release-notes.py`, whose
  generated "OSISM kolla defaults (reference)" section fetched the monolith by
  name and told readers `all/099-kolla.yml` wins over it. It now lists the layer
  from the git tree, modelled on the existing `list_patch_files`.
- **The section is all-or-nothing.** It is labelled "the effective kolla defaults
  of this release" and every configuration recommendation is checked against it,
  so a version missing part of what it lists is worse than no section — a reader
  cannot tell the difference. `list_mirror_layer_files` returns `None` when the
  listing fails or is truncated, and `[]` only when the listing succeeded and
  matched nothing; the caller drops the whole section on `None`, and on any raw
  fetch that fails. Deliberately unlike `list_patch_files`, which warns and
  returns its partial list. This also tightens pre-existing behaviour — the old
  code skipped an unfetchable file and published the rest, so a failed
  `all/099-kolla.yml` already produced a partial section. Going from two requests
  to fifty-seven is what made that worth fixing here.
- Adds the first tests `release-notes.py` has ever had. Nothing under `tests/`
  covered it, so the suite could not catch a regression there at all.

**No behaviour change while the mirror is a single file**, which is what makes it
safe to merge before `osism/defaults` splits.

### Verification

412 tests pass; `flake8` and `black` clean.

### Ordering

This is step 1 of three changes across two repos that must merge in order. See
the tracking issue for the full plan and for what breaks if the order is
reversed.

- osism/issues#1436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
