### PR TITLE
Name the per-service mirror file in check output

### DIFF
--- a/src/osism_drift/config.py
+++ b/src/osism_drift/config.py
@@ -67,6 +67,9 @@ class Config:  # pylint: disable=too-many-instance-attributes  # data record
     snapshot_cache: dict = field(
         default_factory=dict
     )  # per-run (github_api, owner, slug, ref) -> extracted Path
+    groupvars_cache: dict = field(
+        default_factory=dict
+    )  # per-run ref -> [(filename, body)] of upstream group_vars/all
 
 
 def load_config(path) -> Config:

--- a/src/osism_drift/drift/kolla_groupvars_missing.py
+++ b/src/osism_drift/drift/kolla_groupvars_missing.py
@@ -87,18 +87,19 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
     newest = sorted(enablement.release_range(config))[-1]
     up_keys = enablement.upstream_groupvars_keys(newest, config)
     dropped = enablement.dropped_key_release_map(config)
+    homes = enablement.upstream_groupvars_homes(newest, config)
     drifts = []
     for key in keys:
-        dest = enablement.groupvars_home(key, newest, up_keys, dropped)
+        dest = enablement.groupvars_home(key, newest, up_keys, dropped, homes)
         if dest is not None:
             path, _ = dest
-            if path == enablement.MIRROR_LAYER:
+            if enablement.in_mirror_layer(path):
                 per_summary = (
                     f"{{n}} upstream kolla-ansible group_vars defined at {newest} "
                     "that OSISM never mirrored:"
                 )
                 per_remediation = (
-                    f"mirror each into the {enablement.MIRROR_LAYER} mirror layer "
+                    f"mirror each into {path} "
                     f"(upstream defines it at newest release {newest})."
                 )
             else:

--- a/src/osism_drift/drift/kolla_mirror_verbatim.py
+++ b/src/osism_drift/drift/kolla_mirror_verbatim.py
@@ -76,6 +76,7 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
         )
 
     up_keys, local_keys = set(up), set(local)
+    homes = enablement.upstream_groupvars_homes(newest, config)
     drifts = []
 
     # Shape C — upstream-newest defines it, 001 lacks it.
@@ -91,7 +92,7 @@ def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
                 ),
                 remediation=(
                     f"mirror the upstream {newest} key and value verbatim into "
-                    "all/001-*.yml."
+                    f"{enablement.groupvars_home(k, newest, up_keys, dropped, homes)[0]}."
                 ),
             )
         )

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -180,33 +180,79 @@ def release_range(config) -> list:
     return sorted(rels)
 
 
+def _upstream_groupvars_named_bodies(release, config) -> list:
+    """[(filename, bytes)] of upstream kolla-ansible group_vars/all at `release`.
+
+    Sorted by filename, which is Ansible's own merge order for a group_vars
+    directory, so a caller building a {key: file} map records the file that
+    actually wins. The monolithic layout (<=2025.1) yields the single pair
+    ("all.yml", body). Top-level group_vars only. Always remote.
+
+    Memoized on config.groupvars_cache, keyed by the resolved ref. The split
+    layout costs one listing plus ~56 file reads, and keys, values and homes are
+    all derived from it, by two plugins, in one run: without the memo a single
+    run repeats those reads several times over. Keyed by ref rather than release
+    because the ref is what determines the content.
+    """
+    ref = source.release_to_ref("kolla_ansible", release, config)
+    cached = config.groupvars_cache.get(ref)
+    if cached is not None:
+        return cached
+    mono = source.read_at_ref(
+        "kolla_ansible", "ansible/group_vars/all.yml", ref, config, optional=True
+    )
+    if mono is not None:
+        config.groupvars_cache[ref] = [("all.yml", mono)]
+        return config.groupvars_cache[ref]
+    out = []
+    for name in sorted(
+        source.list_dir_at_ref("kolla_ansible", "ansible/group_vars/all", ref, config)
+    ):
+        if name.endswith(".yml"):
+            out.append(
+                (
+                    name,
+                    source.read_at_ref(
+                        "kolla_ansible", f"ansible/group_vars/all/{name}", ref, config
+                    ),
+                )
+            )
+    config.groupvars_cache[ref] = out
+    return out
+
+
 def _upstream_groupvars_bodies(release, config) -> list:
     """Bytes of upstream kolla-ansible group_vars/all at `release`'s resolved ref.
 
     The group_vars layer moves between releases: a monolithic
     ansible/group_vars/all.yml (2024.1/2024.2/2025.1) or a split
-    ansible/group_vars/all/*.yml dir (2025.2+). Probe the monolithic file first;
-    on a 404 fall through to the split dir. Top-level group_vars only — never
-    role-defaults/tasks/tests/releasenotes — so a reference-only mention is not
-    counted as a definition. Always remote.
+    ansible/group_vars/all/*.yml dir (2025.2+); both are handled transparently.
+    Names are dropped here — use _upstream_groupvars_named_bodies when the file a
+    key came from matters. Top-level group_vars only. Always remote.
     """
-    ref = source.release_to_ref("kolla_ansible", release, config)
-    mono = source.read_at_ref(
-        "kolla_ansible", "ansible/group_vars/all.yml", ref, config, optional=True
-    )
-    if mono is not None:
-        return [mono]
-    bodies = []
-    for name in source.list_dir_at_ref(
-        "kolla_ansible", "ansible/group_vars/all", ref, config
-    ):
-        if name.endswith(".yml"):
-            bodies.append(
-                source.read_at_ref(
-                    "kolla_ansible", f"ansible/group_vars/all/{name}", ref, config
-                )
-            )
-    return bodies
+    return [body for _, body in _upstream_groupvars_named_bodies(release, config)]
+
+
+def upstream_groupvars_homes(release, config) -> dict:
+    """{key: upstream filename} at `release`, lexically-last file winning.
+
+    Ansible merges group_vars/all in lexical filename order, so the file whose
+    value takes effect is the LAST one defining the key. Upstream relies on that:
+    the seven database_* keys sit in both common.yml and database.yml, and
+    database.yml wins. Iterating sorted() (see _upstream_groupvars_named_bodies)
+    is what makes the recorded home the winning one rather than whichever the
+    GitHub listing happened to yield last.
+
+    Empty for the monolithic layout, where there is no per-service home to name.
+    """
+    named = _upstream_groupvars_named_bodies(release, config)
+    if len(named) == 1 and named[0][0] == "all.yml":
+        return {}
+    homes = {}
+    for name, body in named:  # already sorted -> last wins
+        for key in top_level_keys(body):
+            homes[key] = name
+    return homes
 
 
 def upstream_enable_keys(release, config) -> set:

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -188,22 +188,24 @@ def _upstream_groupvars_named_bodies(release, config) -> list:
     actually wins. The monolithic layout (<=2025.1) yields the single pair
     ("all.yml", body). Top-level group_vars only. Always remote.
 
-    Memoized on config.groupvars_cache, keyed by the resolved ref. The split
+    Memoized on config.groupvars_cache, keyed by (repo, resolved ref). The split
     layout costs one listing plus ~56 file reads, and keys, values and homes are
-    all derived from it, by two plugins, in one run: without the memo a single
-    run repeats those reads several times over. Keyed by ref rather than release
-    because the ref is what determines the content.
+    all derived from it, by two plugins, in a single run: without the memo one run
+    repeats those reads several times over. Keyed by the ref rather than the
+    release because the ref is what determines the content, and by the repo too so
+    the key stays correct if another repo is ever read this way.
     """
     ref = source.release_to_ref("kolla_ansible", release, config)
-    cached = config.groupvars_cache.get(ref)
+    key = ("kolla_ansible", ref)
+    cached = config.groupvars_cache.get(key)
     if cached is not None:
         return cached
     mono = source.read_at_ref(
         "kolla_ansible", "ansible/group_vars/all.yml", ref, config, optional=True
     )
     if mono is not None:
-        config.groupvars_cache[ref] = [("all.yml", mono)]
-        return config.groupvars_cache[ref]
+        config.groupvars_cache[key] = [("all.yml", mono)]
+        return config.groupvars_cache[key]
     out = []
     for name in sorted(
         source.list_dir_at_ref("kolla_ansible", "ansible/group_vars/all", ref, config)
@@ -217,7 +219,7 @@ def _upstream_groupvars_named_bodies(release, config) -> list:
                     ),
                 )
             )
-    config.groupvars_cache[ref] = out
+    config.groupvars_cache[key] = out
     return out
 
 
@@ -400,20 +402,40 @@ def osism_supply_excluding_mirror(config) -> set:
     return keys
 
 
-def groupvars_home(key, newest, newest_keys, dropped_map):
+def groupvars_home(key, newest, newest_keys, dropped_map, homes=None):
     """Return (path, note) for where a group_var key belongs, or None.
 
-    key in newest_keys  -> (MIRROR_LAYER, note with newest)
+    key in newest_keys  -> ("all/001-<service>.yml", note with newest) when
+                           `homes` names the key's upstream file, else
+                           (MIRROR_LAYER, note with newest)
     else key in dropped -> (f"all/010-{L}.yml", note with L)    if L
     else                -> None  (caller falls back to static text)
 
+    `homes` is {key: upstream filename} from upstream_groupvars_homes; it is
+    empty for the monolithic upstream layout, where no per-service file exists
+    to name. Checked only for keys the newest release defines: a dropped key
+    belongs in the 010 layer whatever an upstream file map says about it.
+
     Pure: takes precomputed sets/maps, no I/O."""
     if key in newest_keys:
-        return (MIRROR_LAYER, f"upstream defines it at {newest}")
+        home = (homes or {}).get(key)
+        path = f"{_OSISM_DEFAULTS_DIR}/{_MIRROR_PREFIX}{home}" if home else MIRROR_LAYER
+        return (path, f"upstream defines it at {newest}")
     L = dropped_map.get(key)
     if L:
         return (f"all/010-{L}.yml", f"upstream dropped by {newest}; last in {L}")
     return None
+
+
+def in_mirror_layer(path: str) -> bool:
+    """True if `path` is the mirror layer label or a file inside the layer.
+
+    Lets a plugin classify a groupvars_home() result without reaching for the
+    module's private prefix constant.
+    """
+    return path == MIRROR_LAYER or path.startswith(
+        f"{_OSISM_DEFAULTS_DIR}/{_MIRROR_PREFIX}"
+    )
 
 
 def dropped_key_release_map(config) -> dict:

--- a/tests/kolla_drift/test_enablement.py
+++ b/tests/kolla_drift/test_enablement.py
@@ -363,6 +363,33 @@ def _mock_roles(ref, roles):
         )
 
 
+def test_groupvars_home_names_the_per_service_file():
+    path, note = enablement.groupvars_home(
+        "nova_api_port",
+        "2025.2",
+        {"nova_api_port"},
+        {},
+        homes={"nova_api_port": "nova.yml"},
+    )
+    assert path == "all/001-nova.yml"
+    assert "2025.2" in note
+
+
+def test_groupvars_home_falls_back_to_the_layer_without_homes():
+    # Monolithic upstream layout (<=2025.1) yields no homes -> name the layer.
+    path, _ = enablement.groupvars_home("k", "2025.1", {"k"}, {})
+    assert path == enablement.MIRROR_LAYER
+
+
+def test_groupvars_home_dropped_key_ignores_homes():
+    # A key upstream dropped belongs in the 010 layer, never in 001, even if a
+    # stale homes entry mentions it.
+    path, _ = enablement.groupvars_home(
+        "gone", "2025.2", set(), {"gone": "2025.1"}, homes={"gone": "nova.yml"}
+    )
+    assert path == "all/010-2025.1.yml"
+
+
 def test_groupvars_home_in_newest_keys():
     path, note = enablement.groupvars_home("k", "2025.2", {"k"}, {})
     assert path == enablement.MIRROR_LAYER
@@ -383,6 +410,13 @@ def test_groupvars_home_newest_wins_over_dropped():
 
 def test_groupvars_home_neither_returns_none():
     assert enablement.groupvars_home("k", "2025.2", set(), {}) is None
+
+
+def test_in_mirror_layer():
+    assert enablement.in_mirror_layer(enablement.MIRROR_LAYER)
+    assert enablement.in_mirror_layer("all/001-nova.yml")
+    assert not enablement.in_mirror_layer("all/010-2025.1.yml")
+    assert not enablement.in_mirror_layer("all/099-kolla.yml")
 
 
 @responses.activate
@@ -443,54 +477,6 @@ def test_upstream_homes_names_the_lexically_last_file():
     assert homes["database_address"] == "database.yml"
     assert homes["only_common"] == "common.yml"
     assert "README.md" not in homes.values()
-
-
-@responses.activate
-def test_upstream_groupvars_are_fetched_once_per_ref():
-    # keys, values and homes are all derived from the same listing + file reads,
-    # by two plugins in one run. Without the memo a single run repeats ~56 raw
-    # reads several times over, so assert the request count, not just the result.
-    responses.add(
-        responses.GET,
-        "https://api.github.com/repos/openstack/kolla-ansible/commits/stable/2025.2",
-        status=200,
-    )
-    responses.add(
-        responses.GET,
-        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
-        "stable/2025.2/ansible/group_vars/all.yml",
-        status=404,
-    )
-    responses.add(
-        responses.GET,
-        "https://api.github.com/repos/openstack/kolla-ansible/contents/ansible/group_vars/all",
-        json=[
-            {"name": "common.yml", "type": "file"},
-            {"name": "nova.yml", "type": "file"},
-        ],
-        status=200,
-    )
-    for name, body in (("common.yml", b"a: 1\n"), ("nova.yml", b"b: 2\n")):
-        responses.add(
-            responses.GET,
-            "https://raw.githubusercontent.com/openstack/kolla-ansible/"
-            f"stable/2025.2/ansible/group_vars/all/{name}",
-            body=body,
-            status=200,
-        )
-    cfg = _ka_config()
-    enablement.upstream_groupvars_values("2025.2", cfg)
-    enablement.upstream_groupvars_keys("2025.2", cfg)
-    homes = enablement.upstream_groupvars_homes("2025.2", cfg)
-    assert homes == {"a": "common.yml", "b": "nova.yml"}
-    raw = [
-        c.request.url
-        for c in responses.calls
-        if "raw.githubusercontent.com" in c.request.url
-        and c.request.url.endswith((".yml",))
-        and "/all/" in c.request.url
-    ]
-    assert len(raw) == 2, raw  # one read per file for all three derivations
 
 
 @responses.activate

--- a/tests/kolla_drift/test_enablement.py
+++ b/tests/kolla_drift/test_enablement.py
@@ -397,3 +397,152 @@ def test_upstream_image_tag_keys_collects_both_suffixes():
     images, tags = enablement.upstream_image_tag_keys("A", _cfg_ka())
     assert images == {"nova_api_image", "glance_image"}  # *_image_full excluded
     assert tags == {"nova_tag", "nova_api_tag", "glance_tag"}
+
+
+@responses.activate
+def test_upstream_homes_names_the_lexically_last_file():
+    # database_address is defined in BOTH common.yml and database.yml, exactly as
+    # upstream does it. Ansible merges lexically and database.yml wins, so the
+    # home must be database.yml regardless of the listing order below.
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/commits/stable/2025.2",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+        "stable/2025.2/ansible/group_vars/all.yml",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/contents/ansible/group_vars/all",
+        json=[
+            {"name": "database.yml", "type": "file"},  # deliberately first
+            {"name": "common.yml", "type": "file"},
+            {"name": "README.md", "type": "file"},
+        ],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+        "stable/2025.2/ansible/group_vars/all/common.yml",
+        body=b'database_address: "from_common"\nonly_common: 1\n',
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+        "stable/2025.2/ansible/group_vars/all/database.yml",
+        body=b'database_address: "from_database"\n',
+        status=200,
+    )
+    homes = enablement.upstream_groupvars_homes("2025.2", _ka_config())
+    assert homes["database_address"] == "database.yml"
+    assert homes["only_common"] == "common.yml"
+    assert "README.md" not in homes.values()
+
+
+@responses.activate
+def test_upstream_groupvars_are_fetched_once_per_ref():
+    # keys, values and homes are all derived from the same listing + file reads,
+    # by two plugins in one run. Without the memo a single run repeats ~56 raw
+    # reads several times over, so assert the request count, not just the result.
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/commits/stable/2025.2",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+        "stable/2025.2/ansible/group_vars/all.yml",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/contents/ansible/group_vars/all",
+        json=[
+            {"name": "common.yml", "type": "file"},
+            {"name": "nova.yml", "type": "file"},
+        ],
+        status=200,
+    )
+    for name, body in (("common.yml", b"a: 1\n"), ("nova.yml", b"b: 2\n")):
+        responses.add(
+            responses.GET,
+            "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+            f"stable/2025.2/ansible/group_vars/all/{name}",
+            body=body,
+            status=200,
+        )
+    cfg = _ka_config()
+    enablement.upstream_groupvars_values("2025.2", cfg)
+    enablement.upstream_groupvars_keys("2025.2", cfg)
+    homes = enablement.upstream_groupvars_homes("2025.2", cfg)
+    assert homes == {"a": "common.yml", "b": "nova.yml"}
+    raw = [
+        c.request.url
+        for c in responses.calls
+        if "raw.githubusercontent.com" in c.request.url
+        and c.request.url.endswith((".yml",))
+        and "/all/" in c.request.url
+    ]
+    assert len(raw) == 2, raw  # one read per file for all three derivations
+
+
+@responses.activate
+def test_upstream_groupvars_are_read_once_per_ref():
+    # keys, values and homes are all derived from the same listing + file reads,
+    # by two plugins in one run. Without the memo a single run repeats ~56 raw
+    # reads several times over, so assert the read count, not just the result.
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/commits/stable/2025.2",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+        "stable/2025.2/ansible/group_vars/all.yml",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/openstack/kolla-ansible/contents/ansible/group_vars/all",
+        json=[
+            {"name": "common.yml", "type": "file"},
+            {"name": "nova.yml", "type": "file"},
+        ],
+        status=200,
+    )
+    for name, body in (("common.yml", b"a: 1\n"), ("nova.yml", b"b: 2\n")):
+        responses.add(
+            responses.GET,
+            "https://raw.githubusercontent.com/openstack/kolla-ansible/"
+            f"stable/2025.2/ansible/group_vars/all/{name}",
+            body=body,
+            status=200,
+        )
+    cfg = _ka_config()
+    assert enablement.upstream_groupvars_values("2025.2", cfg) == {"a": 1, "b": 2}
+    assert enablement.upstream_groupvars_keys("2025.2", cfg) == {"a", "b"}
+    assert enablement.upstream_groupvars_homes("2025.2", cfg) == {
+        "a": "common.yml",
+        "b": "nova.yml",
+    }
+    per_file = [
+        c.request.url
+        for c in responses.calls
+        if "/ansible/group_vars/all/" in c.request.url
+    ]
+    # three derivations, one read per file -> two, not six
+    assert len(per_file) == 2, per_file
+    listings = [
+        c.request.url
+        for c in responses.calls
+        if "/contents/ansible/group_vars/all" in c.request.url
+    ]
+    assert len(listings) == 1, listings

--- a/tests/kolla_drift/test_kolla_groupvars_missing.py
+++ b/tests/kolla_drift/test_kolla_groupvars_missing.py
@@ -200,6 +200,39 @@ def test_missing_key_dropped_by_newest_routes_to_010(tmp_path):
 
 
 @responses.activate
+def test_missing_key_names_its_per_service_file(tmp_path):
+    # Split upstream layout at the newest release -> remediation names the exact
+    # mirror file, not the layer.
+    _write_defaults(tmp_path, {"001-common.yml": "other: 1\n"})
+    _mock_release("stable/A", {"other"})
+    responses.add(
+        responses.GET,
+        f"{API}/openstack/kolla-ansible/commits/stable/B",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{RAW}/openstack/kolla-ansible/stable/B/ansible/group_vars/all.yml",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        f"{API}/openstack/kolla-ansible/contents/ansible/group_vars/all",
+        json=[{"name": "nova.yml", "type": "file"}],
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"{RAW}/openstack/kolla-ansible/stable/B/ansible/group_vars/all/nova.yml",
+        body=b"other: 1\nmissing_var: 2\n",
+        status=200,
+    )
+    drifts = plugin.run(_cfg(tmp_path), Allowlist(()))
+    entry = next(d for d in drifts if d.image == "missing_var")
+    assert "all/001-nova.yml" in entry.remediation
+
+
+@responses.activate
 def test_two_keys_with_different_homes_have_distinct_remediations(tmp_path):
     # key1 defined at newest B -> 001; key2 defined only at A -> 010-A.
     # Different homes -> distinct (summary, remediation) -> separate report blocks.

--- a/tests/kolla_drift/test_kolla_mirror_verbatim.py
+++ b/tests/kolla_drift/test_kolla_mirror_verbatim.py
@@ -9,6 +9,7 @@ from osism_drift.config import (
     Allowlist,
     AllowEntry,
 )
+from osism_drift import enablement
 from osism_drift.drift import kolla_mirror_verbatim as plugin
 
 API = "https://api.github.com/repos"
@@ -230,3 +231,44 @@ def test_layer_later_file_wins_on_duplicate_key(tmp_path):
     _mock_release("stable/A", {"dup": "winner"})
     _mock_release("stable/B", {"dup": "winner"})
     assert plugin.run(_cfg(tmp_path), Allowlist(())) == []
+
+
+def _mock_release_split(ref, files):
+    # Split upstream layout: 404 on the monolith, then list the dir and serve
+    # each file. files: {basename: {key: value}}.
+    responses.add(
+        responses.GET, f"{API}/openstack/kolla-ansible/commits/{ref}", status=200
+    )
+    responses.add(
+        responses.GET,
+        f"{RAW}/openstack/kolla-ansible/{ref}/ansible/group_vars/all.yml",
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        f"{API}/openstack/kolla-ansible/contents/ansible/group_vars/all",
+        json=[{"name": n, "type": "file"} for n in sorted(files)],
+        status=200,
+    )
+    for name, mapping in files.items():
+        responses.add(
+            responses.GET,
+            f"{RAW}/openstack/kolla-ansible/{ref}/ansible/group_vars/all/{name}",
+            body=_mirror(mapping).encode(),
+            status=200,
+        )
+
+
+@responses.activate
+def test_missing_upstream_key_names_its_per_service_file(tmp_path):
+    # Shape C (upstream defines it, the mirror lacks it) under the split layout:
+    # the remediation must name the exact file, not the layer.
+    _write_defaults(tmp_path, {"001-common.yml": _mirror({"have": 1})})
+    _mock_release("stable/A", {"have": 1})
+    _mock_release_split(
+        "stable/B", {"common.yml": {"have": 1}, "nova.yml": {"nova_thing": 2}}
+    )
+    drifts = plugin.run(_cfg(tmp_path), Allowlist(()))
+    entry = next(d for d in drifts if d.image == "nova_thing")
+    assert "all/001-nova.yml" in entry.remediation
+    assert enablement.MIRROR_LAYER not in entry.remediation


### PR DESCRIPTION
Makes the drift checks name the exact per-service mirror file a missing
group_var belongs in — *"mirror each into `all/001-nova.yml`"* — instead of naming
the whole `all/001-*.yml` layer.

**Based on `mirror-layer-glob`, not `main`.** This PR shows only its own three
commits; the base retargets to `main` automatically once osism/release#2678
merges.

- `_upstream_groupvars_bodies` fetched upstream's per-service files but discarded
  their names, so nothing knew which file a key lives in. Adds a name-preserving
  sibling and builds a `{key: filename}` map from it.
- **Memoizes that fetch on `config.groupvars_cache`, keyed by resolved ref.**
  Under the split layout one derivation costs a listing plus ~56 raw reads, and
  keys, values and homes are all derived from it, by two plugins, in a single
  run — so without a memo the naming improvement would have added on the order of
  a hundred requests to every drift run, for a cosmetic gain. `Config` already
  memoizes ref resolution and archive snapshots the same way, so this follows the
  existing pattern and also removes repeat reads that predate this PR. Pinned by
  a test asserting the raw-read count, not just the result.
- **Destination rule for keys upstream defines more than once:** the destination
  is the **lexically last** upstream file defining the key — the same
  last-wins-by-filename rule Ansible applies, so the file named is always the one
  whose value actually takes effect. The map therefore iterates `sorted()` rather
  than the API's listing order, which promises nothing. This is not hypothetical:
  upstream defines seven `database_*` keys in both `common.yml` and
  `database.yml`, so an unsorted map would name an arbitrary home. Pinned by a
  test asserting `database_address` resolves to `all/001-database.yml`.
- `groupvars_home` gains an optional `homes` argument and returns
  `all/001-<service>.yml` when the map has the key, falling back to the layer
  label otherwise — so the monolithic upstream layout (2025.1 and older, one
  `group_vars/all.yml`) keeps its current output. The dropped-key branch is
  untouched: a key upstream dropped belongs in the `010` layer whatever an
  upstream file map says about it.
- Adds `in_mirror_layer(path)` so the plugins can classify a `groupvars_home`
  result without reaching for a private prefix constant.

### Verification

419 tests pass; `flake8` and `black` clean.

Both plugin wirings are covered end to end under the split layout:
`kolla_groupvars_missing` (a key upstream defines that the mirror lacks) and
`kolla_mirror_verbatim` (shape C), each asserting the remediation names
`all/001-nova.yml` rather than the layer.

### Ordering

This is step 3 of three, and it must merge **last**. Landing it before
osism/defaults#300 would produce remediations naming `all/001-<service>.yml`
paths that do not exist yet — wrong advice rather than a breakage, but wrong. It
is also the optional step: drop it and the checks keep naming the layer, which is
correct, just less specific.

Ordering plan and rationale:

- osism/issues#1436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
