### PR TITLE
Add sync-mirror: automate the per-release kolla mirror re-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 .pytest_cache/
 .tox/
 release-notes-*.md
+
+# sync-mirror detail reports
+sync-mirror-*.txt

--- a/docs/sync-mirror-tutorial.md
+++ b/docs/sync-mirror-tutorial.md
@@ -1,0 +1,327 @@
+# sync-mirror tutorial: a complete re-sync
+
+A walk through one real re-sync of the `osism/defaults` kolla mirror, for
+OpenStack **2026.1**: report, decide, apply, commit. Every command and every
+block of output below is from an actual run.
+
+For what the tool is and why each rule exists, see
+[sync-mirror.md](sync-mirror.md). This page assumes you have not run it before.
+
+**A note on the numbers.** The counts here are from a re-sync measured on
+2026-08-27 against `osism/defaults` main. Upstream moves; your run will differ.
+
+## What you need
+
+Local checkouts of `osism/defaults`, `osism/release` (this repo) and
+`openstack/kolla-ansible`, arranged so one `--base-dir` per org finds them. The
+rest of this page uses two variables for those roots — set them to wherever
+yours live:
+
+    export OSISM_BASE=~/src/osism
+    export OPENSTACK_BASE=~/src/openstack
+
+    $OSISM_BASE/defaults
+    $OSISM_BASE/release
+    $OPENSTACK_BASE/kolla-ansible
+
+Fetch kolla-ansible before you start. sync-mirror pins to a commit before
+reading anything, so a stale clone gives you a stale — but internally
+consistent — result.
+
+## Step 1: work on a branch
+
+sync-mirror computes the re-sync from a ref, never from your working tree.
+`--base-ref` names the commit it treats as the "before" state of the mirror, so
+anything that ref is missing is reported as part of your re-sync. It defaults to
+`origin/main`. Make a branch and point the tool at it:
+
+    cd $OSISM_BASE/defaults
+    git switch -c sync-2026.1 origin/main
+
+In this walkthrough nothing is committed to that branch — the re-sync itself is
+committed in the worktree at step 6 — so `--base-ref origin/main` would serve
+just as well. The branch earns its place when a key needs `--retain`: retention
+is a gate you write by hand in `all/099-kolla.yml`, and sync-mirror only sees it
+once it is committed to the ref you pass.
+
+If the mirror work you are building on is still on a review branch, base there
+instead. Pointing at `origin/main` when the intended base was a branch ahead of
+it added 52 spurious "files added" and one spurious semantic key to this
+re-sync's report.
+
+## Step 2: create a report
+
+    cd $OSISM_BASE/release
+    tox -e sync-mirror -- --target 2026.1 --base-ref sync-2026.1 \
+        --defaults-dir $OSISM_BASE/defaults \
+        --base-dir $OSISM_BASE --base-dir $OPENSTACK_BASE
+
+That builds a throwaway git worktree of your branch, computes the plan against
+it, writes `sync-mirror-2026.1.txt` in the current directory with every changed
+value in full, prints a summary, and removes the worktree. Nothing in `defaults`
+changes.
+
+The summary opens with what it compared and what it found:
+
+    target        2026.1 @ 6e12d225082ab0ff2273d61febbdd8fb2bfa6e22
+    defaults base sync-2026.1 @ faa403c18333650eb6d3b25cb89aa1752ae4fae5
+
+    131 mirror values changed. 15 need a decision from you; the rest are carried through.
+
+      semantic         15  meaning changed and no rule explains it; blocks --apply
+      notation          2  identical Jinja once whitespace beside {{ }} / {% %} is collapsed
+      representation  101  bool spelling changed, truth value did not ('no' -> False)
+      overridden       13  an unconditional OSISM layer already supplies the key
+
+Only `semantic` needs a decision; the other 116 values are reported for
+traceability.
+
+It ends with the part you act on — the semantic keys, by name:
+
+    needs a disposition (--accept-upstream / --retain / --retain-unverified):
+      cloudkitty_storage_backend
+      computes_need_external_bridge
+      enable_opensearch
+      enable_placement
+      haproxy_ssl_settings
+      kolla_base_distro_version_default_map
+      kolla_same_external_internal_vip
+      letsencrypt_managed_certs
+      mariadb_default_database_shard_hosts
+      om_rabbitmq_qos_prefetch_count
+      opensearch_dashboards_port_external
+      openstack_auth
+      prometheus_alertmanager_public_port
+      ssl_intermediate_settings
+      ssl_modern_settings
+
+    full values for every key: $OSISM_BASE/release/sync-mirror-2026.1.txt
+
+    exit 2: operator action needed; the plan was not applied
+
+(That path is printed resolved, not as a variable.)
+
+## Step 3: read the semantic changes
+
+That closing list is only the names. Further up, the same report gives each of
+those keys its change and the upstream commit behind it — inlining the value
+when it is short enough to read and describing its shape when it is not:
+
+    semantic (15) - each needs --accept-upstream / --retain / --retain-unverified
+      cloudkitty_storage_backend: 'influxdb' -> 'sqlalchemy'
+          upstream: f1e847851 influxdb/telegraf: Drop deployment
+      enable_placement: '{{ enable_nova | bool or enable_zun | bool }}' -> '{{ enable_nova | bool }}'
+          upstream: 9f1256ba7 Drop zun and kuryr
+      om_rabbitmq_qos_prefetch_count: '1' -> '50'
+          upstream: 4232989db rabbitmq: Bump default rabbit_qos_prefetch_count from 1 to 50
+      letsencrypt_managed_certs: str, 433 chars -> multi-line str, 435 chars (see report)
+          upstream: b877cb060 ansible-lint: fix yaml[line-length] in group_vars
+      ssl_modern_settings: multi-line str, 394 chars -> multi-line str, 306 chars (see report)
+          upstream: b877cb060 ansible-lint: fix yaml[line-length] in group_vars
+          upstream: 78f3c2b5d ansible-lint: Remove yaml[truthy] from excludes
+
+The upstream subject is usually enough to decide. `9f1256ba7 Drop zun and kuryr`
+tells you `enable_placement` no longer needs to consider zun, because zun is gone.
+
+For the ones described by shape, open the report file named at the end of the
+output — `./sync-mirror-2026.1.txt`. It holds every value in full, laid out over
+as many lines as the value has:
+
+    -- ssl_modern_settings
+       upstream: b877cb060 ansible-lint: fix yaml[line-length] in group_vars
+       upstream: 78f3c2b5d ansible-lint: Remove yaml[truthy] from excludes
+
+       mirror (current):
+         ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:...
+         ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 ...
+
+       upstream 2026.1:
+         ssl-default-bind-ciphersuites {{ _ssl_modern_ciphersuites | join(':') }}
+         ssl-default-bind-options {{ (['prefer-client-ciphers'] + _ssl_modern_options) | join(' ') }}
+
+Despite the `yaml[line-length]` subject, this is **not** a re-wrap: upstream
+replaced literal ciphersuite lists with references to new variables. The
+upstream subject is not a reliable guide on its own — read the report for
+anything you are not sure about.
+
+## Step 4: disposition each key
+
+Three flags, one per key. See [sync-mirror.md](sync-mirror.md#dispositions) for
+the full rules.
+
+**Accepting upstream** is the common case — the change is intended and OSISM has
+no opinion:
+
+    --accept-upstream enable_placement
+
+**Retaining the OSISM value** requires a `099` release gate, which you write by
+hand. `--retain` does not write it; it **verifies** it. Retain something with no
+gate and the run refuses:
+
+    $ tox -e sync-mirror -- ... --retain om_rabbitmq_qos_prefetch_count
+    om_rabbitmq_qos_prefetch_count: no later layer supplies it, so nothing
+    retains the old value for the older releases
+    # exit 3
+
+Retention means:
+
+1. add the gate to `all/099-kolla.yml`, listing the older releases with `else`
+   the current value. Had OSISM wanted to keep the old prefetch count instead of
+   accepting upstream's bump from `'1'` to `'50'`:
+
+       om_rabbitmq_qos_prefetch_count: "{{ '1' if openstack_version in ['2024.1', '2024.2', '2025.1', '2025.2'] else '50' }}"
+
+2. **commit it** on the branch from step 1 — sync-mirror computes the plan
+   from a worktree of `--base-ref`, so an uncommitted gate is invisible to it;
+3. re-run with `--retain om_rabbitmq_qos_prefetch_count`, and sync-mirror
+   confirms the gate is there and binds the right value to the right release:
+
+       dispositioned:
+         om_rabbitmq_qos_prefetch_count: verified against the canonical gate in all/099-kolla.yml
+
+Only that one shape can be verified. A compound condition, a `not in`, a nested
+ternary or a variable branch is a legitimate gate that the parser cannot read,
+and takes `--retain-unverified` instead — see
+[Dispositions](sync-mirror.md#dispositions).
+
+A gated key still comes out `semantic` and still needs its flag on every run:
+the gate makes the claim checkable, it does not remove the decision.
+
+A `--retain` that merely recorded your intent would let the re-sync report "all
+dispositioned" while the old value quietly disappeared.
+
+In this re-sync all fifteen were accepted upstream: the re-wraps and the
+ansible-lint truthy sweep are intended, zun and influxdb are gone, and the
+rabbitmq prefetch bump is an upstream default OSISM does not override.
+
+## Step 5: apply
+
+Dispositions on their own change nothing: they are validated, and the run still
+ends at `exit 1: changes ready to apply; re-run with --apply`. Writing takes
+`--apply` as well:
+
+    tox -e sync-mirror -- --target 2026.1 --base-ref sync-2026.1 \
+        --defaults-dir $OSISM_BASE/defaults \
+        --base-dir $OSISM_BASE --base-dir $OPENSTACK_BASE \
+        --accept-upstream cloudkitty_storage_backend \
+        --accept-upstream computes_need_external_bridge \
+        --accept-upstream enable_opensearch \
+        --accept-upstream enable_placement \
+        --accept-upstream haproxy_ssl_settings \
+        --accept-upstream kolla_base_distro_version_default_map \
+        --accept-upstream kolla_same_external_internal_vip \
+        --accept-upstream letsencrypt_managed_certs \
+        --accept-upstream mariadb_default_database_shard_hosts \
+        --accept-upstream om_rabbitmq_qos_prefetch_count \
+        --accept-upstream opensearch_dashboards_port_external \
+        --accept-upstream openstack_auth \
+        --accept-upstream prometheus_alertmanager_public_port \
+        --accept-upstream ssl_intermediate_settings \
+        --accept-upstream ssl_modern_settings \
+        --apply
+
+The report now ends differently:
+
+    dispositioned:
+      cloudkitty_storage_backend: upstream value accepted for every supported release
+      ...
+
+    exit 0: the plan was applied to the worktree
+
+    applied: 47 written, 4 deleted
+
+    verify with:
+    PYTHONPATH=src python3 src/check-drift.py --group all \
+        --base-dir $OSISM_BASE/defaults.worktrees/sync-2026.1 \
+        --base-dir $OSISM_BASE \
+        --base-dir $OPENSTACK_BASE \
+        --remote-fallback
+
+(The tool prints those roots fully resolved, not as variables.)
+
+Nothing in your `defaults` checkout changed. `--apply` writes into the throwaway
+worktree and, unlike a report run, **keeps** it — that tree is the artifact to
+review. Run the printed `check-drift` command to measure it; the paths are
+already correct, including the worktree ordering that a hand-written invocation
+usually gets wrong.
+
+If a release newer than your target is already declared, that command measures
+the *newer* release rather than yours. The report says so and names the config
+override when that applies.
+
+## Step 6: commit the re-sync
+
+Add `--commit` to the apply and sync-mirror does this for you: it branches the
+detached worktree, stages exactly the paths the plan touched, and commits with
+the provenance as the message.
+
+    ... --apply --commit
+
+    committed d6be03956836 on sync-mirror/2026.1 in the worktree
+    amend it to say why each semantic value was accepted or retained -- the
+    provenance is generated, the reasoning is not
+
+`--commit-branch NAME` picks a different branch. To do it by hand instead — the
+worktree is on a **detached HEAD**, so it needs a branch first:
+
+    W=$OSISM_BASE/defaults.worktrees/sync-2026.1/defaults
+    git -C $W switch -c sync-2026.1-mirror
+    git -C $W add all/
+    git -C $W commit
+
+    git -C $W show --stat --format="" HEAD | tail -3
+    # all/010-2025.1.yml | 83 +++++++++++++------------
+    # all/010-2025.2.yml | 48 ++++++++++++++++++
+    # 51 files changed, 459 insertions(+), 303 deletions(-)
+
+sync-mirror never pushes or opens a PR, and commits only when asked. Review the
+diff before you go further — that is what the kept worktree is for.
+
+Either way the message carries the provenance: the pin of every supported
+release, the `defaults` base it was computed from, and each semantic key under
+the disposition you gave it. The pins are also in every generated `010` header,
+but nothing in the tree records the dispositions — accepting upstream leaves no
+trace, because the value simply ends up matching upstream. What the tool cannot
+write is *why*, so amend the commit and say it.
+
+    Generated by sync-mirror for 2026.1.
+
+    Upstream pins (openstack/kolla-ansible ansible/group_vars/all):
+      2024.1: 72d6b6ac6ad4dbc2564ccc4472069a65a3e50111
+      ...
+      2026.1: 6e12d225082ab0ff2273d61febbdd8fb2bfa6e22
+    osism/defaults base: 4bdf3bdfa512519fcfa79db33213b2bd173f13f7
+
+    Dispositions:
+      accepted upstream (15):
+        cloudkitty_storage_backend, computes_need_external_bridge,
+        ...
+
+If you need to recompute this re-sync later — to tell a stale branch from a
+moved upstream — `--format json` writes the same pins machine-readably and
+`--pins-from` feeds them back. It carries the base commit too, so it conflicts
+with `--base-ref`; pass one or the other.
+
+When you are done, remove it:
+
+    git -C $OSISM_BASE/defaults worktree remove $W
+
+## Troubleshooting
+
+**`--defaults-dir is required`** (exit 3) — required in both modes; the plan is
+computed from a worktree of that repo.
+
+**`<path> already exists; remove it`** (exit 3) — a previous `--apply` left its
+worktree behind, by design. Review and remove it, or pass `--worktree-path`.
+
+**`keys [...] given more than one disposition`** (exit 3) — a key takes exactly
+one of the three flags.
+
+**`ModuleNotFoundError: No module named 'requests'`** — you ran
+`./src/sync-mirror.py` with a `python3` that lacks the dependencies. Use
+`tox -e sync-mirror --`, or install them into a virtualenv first:
+`uv venv && uv pip install -r requirements.txt`.
+
+**`upstream <target> ships a monolithic group_vars/all.yml; sync-mirror supports
+the per-service layout only`** (exit 3) — the target release predates the
+per-service split upstream (2025.1 and older).

--- a/docs/sync-mirror.md
+++ b/docs/sync-mirror.md
@@ -1,0 +1,369 @@
+# sync-mirror
+
+Regenerates the kolla mirror layer in [osism/defaults](https://github.com/osism/defaults)
+for one OpenStack release.
+
+The job is to bring the mirror up to a newly supported OpenStack release and
+carry the keys the older supported releases still need. It used to be roughly
+fifteen hand-written commits. sync-mirror computes it as one plan, and stops at
+every point where the right answer is a judgement call rather than a
+derivation.
+
+For a walk through a complete re-sync, see
+[sync-mirror-tutorial.md](sync-mirror-tutorial.md). This page is the reference.
+
+## What the mirror layer is
+
+`osism/defaults` carries upstream kolla-ansible's `ansible/group_vars/all` as a
+set of layers under `all/`, loaded in lexical order:
+
+| Layer | Content | Owner |
+| ------- | --------- | ------- |
+| `001-<service>.yml` | byte-for-byte copy of the upstream file | generated |
+| `010-<L>.yml` | keys `L` defines that the target dropped | generated |
+| `099-kolla.yml` | OSISM's own opinions, overriding the mirror | hand-written |
+
+**The mirror is the `001-*` layer** — that byte-for-byte copy of upstream's
+files, and nothing else. `010-*` carries upstream values too, but re-serialized
+and OSISM-owned, so it is back-compat rather than mirror; `099-kolla.yml` is
+OSISM's own. The distinction is load-bearing: the `kolla_mirror_verbatim`
+check-drift plugin enforces byte-equality on `001-*` alone, which is why
+sync-mirror never reformats a value there — it has no freedom to choose a
+different spelling (see [check-drift-kolla.md](check-drift-kolla.md)) — while it
+owns the YAML style of `010-*` completely.
+
+Where this page says "the mirror" without qualification it means the generated
+set, `001-*` and `010-*` together: what a re-sync computes and `--apply` writes.
+
+When the supported release range moves — say the newest supported release becomes
+2026.1 — three things must happen: the `001` layer must match the new release's
+upstream tree, keys the new release dropped must survive for the older releases
+that still use them, and any value whose *meaning* changed must be consciously
+accepted or deliberately overridden. sync-mirror does the first two and reports
+the third.
+
+## Run it locally
+
+    tox -e sync-mirror -- --target 2026.1 \
+        --defaults-dir ~/src/osism/defaults \
+        --base-dir ~/src/osism --base-dir ~/src/openstack
+
+`tox -e sync-mirror` is the portable form: it creates the environment from
+`requirements.txt`. If you would rather run the script directly — it is
+executable, with a `/usr/bin/env python3` shebang — install the dependencies
+into a virtualenv first:
+
+    uv venv && uv pip install -r requirements.txt
+    . .venv/bin/activate
+    ./src/sync-mirror.py --target 2026.1 ...
+
+`pip install -r requirements.txt` in a venv works the same way. Only `requests`
+and `PyYAML` are actually needed at runtime; a `python3` that already has them
+runs the script as-is.
+
+`--defaults-dir` is required in both modes. `--base-dir` is repeatable and is
+searched in order for each repo sync-mirror needs — `defaults` and `release` from
+the OSISM root, `kolla-ansible` from the OpenStack root.
+
+### Exit codes
+
+| Code | Meaning |
+| ------ | --------- |
+| 0 | nothing to do, or (with `--apply`) the plan was applied |
+| 1 | changes ready to apply; re-run with `--apply` |
+| 2 | operator action needed |
+| 3 | refused; the plan was not applied |
+
+Exit 2 has two causes: a semantic key with no disposition, or an existing `010`
+file the tool does not own. Exit 0 covers two outcomes, so the report's last line
+names which one.
+
+### The commit
+
+`--commit` (with `--apply`) branches the detached worktree, stages exactly the
+paths the plan touched, and commits. The branch defaults to
+`sync-mirror/<target>`; `--commit-branch NAME` overrides it, and an existing
+branch is refused rather than moved. The message is the generated subject, the
+provenance below, and a `Signed-off-by` taken from your git config — without
+that trailer the eventual PR fails Zuul's DCO gate.
+
+It stops there: no push, no PR, and the *reasoning* for each semantic decision
+is yours to add by amending. Without `--commit`, the same provenance is printed
+as a block to paste, wrapped at 72 columns.
+
+The pins are also in every generated `010` header, so the tree is not missing
+them. The dispositions are the part nothing else records — `--accept-upstream`
+leaves no trace at all, since the value simply ends up matching upstream — and
+`--format json` carries the same block as `commit_summary`.
+
+### The detail report
+
+The terminal report inlines only short single-line values; every changed value in
+full goes to a file, written on every run that gets as far as computing a plan —
+report runs and refused applies included, since the values behind a refusal are
+what you need to resolve it.
+
+It lands in the current directory as `sync-mirror-<target>.txt` (gitignored in
+this repo), and the footer prints its absolute path. `--report-file PATH`
+overrides the location.
+
+## It never touches your defaults checkout
+
+Every run builds a throwaway worktree of `--defaults-dir` at
+`<defaults>.worktrees/sync-<target>/defaults`, from `--base-ref`, and works
+there. Report mode removes it on the way out; `--apply` keeps it as the artifact
+to review. Nothing is written into `--defaults-dir` itself, in either mode — the
+only file the tool writes outside the worktree is the detail report above.
+
+Two consequences worth knowing:
+
+- **Your uncommitted work is never consulted.** The plan is computed from
+  `--base-ref`, not from your working tree.
+- **`--base-ref` decides what the re-sync even looks like.** It defaults to
+  `origin/main`, and whatever it names is treated as the "before" state of the
+  mirror — so anything that ref is missing is reported as part of the re-sync.
+  Point it at the commit your re-sync actually starts from, which is not
+  `origin/main` if the mirror work it builds on is still on a review branch. The
+  header echoes what it used:
+
+      target        2026.1 @ 6e12d225082ab0ff2273d61febbdd8fb2bfa6e22
+      defaults base sync-2026.1 @ faa403c18333650eb6d3b25cb89aa1752ae4fae5
+
+  In the 2026.1 re-sync, leaving `--base-ref` at `origin/main` when the intended
+  base was a branch ahead of it added 52 spurious "files added" and one spurious
+  semantic key to the report.
+
+The worktree is created **detached**. After `--apply` you are standing in a
+detached tree holding the changes; `git switch -c <branch>` there, then commit —
+or pass `--commit` and let sync-mirror do it.
+
+## What it computes
+
+Every supported release is pinned to a **commit** before anything is read, so a
+branch advancing mid-run cannot change the result. `--pin` sets the target's
+commit; `--pins-from report.json` replays every pin from a previous run, which is
+what makes a re-sync reproducible after upstream has moved on.
+
+- **`001` layer** — byte copy of the target's upstream `group_vars/all`, plus
+  file additions and deletions as services appear and disappear.
+- **`010-<L>.yml` layers** — a key lands here when the target no longer defines
+  it **and** no other OSISM layer supplies it. `L` is the newest *currently
+  supported* release that still defines the key, because `010-<L>.yml` is retired
+  when `L` reaches EOL. It is **not** "the release where the key was last seen"
+  historically.
+- **Classification** of every changed value, and the upstream commit behind each
+  semantic one.
+
+Because the `010` map is the desired end state rather than a delta, a re-sync
+usually routes keys that are already exactly where they belong. The report says
+so per file, so a large count does not read as a large change:
+
+    keys routed into back-compat layers (75 in the desired tree, not all of them new):
+      all/010-2024.1.yml:  6 keys (same keys and values; only the pin header is refreshed)
+      all/010-2025.2.yml: 31 keys (new file)
+
+A `010` file is rewritten every re-sync regardless, because its header carries each
+release's pinned commit.
+
+### The first regeneration is a one-time normalization
+
+The `010` values are **re-serialized**, unlike the byte-copied `001` layer, so
+the first time the generator rewrites a hand-maintained `010` file the diff is
+large and entirely cosmetic:
+
+- the header prose becomes the generator's fixed text, and `# Source:` becomes
+  the per-release pinned-commit list;
+- YAML style normalizes — flow mappings become block mappings, an empty value
+  becomes an explicit `null`, and mixed list quoting becomes uniform. String
+  values themselves are untouched: the generator emits the same double-quoted
+  style a human wrote.
+
+Because the `010` values are re-serialized, the generator owns their YAML style,
+and it deliberately matches the `001` layer rather than PyYAML's defaults:
+double-quoted string values, bare keys at every depth, sequences indented under
+their key, nested mappings in upstream's order. PyYAML on its own would invert
+all four.
+
+Two of those are correctness rather than taste. `osism/defaults` runs yamllint
+with `extends: default` (line-length disabled, `truthy` enabled), whose
+indentation rule makes an unindented block sequence an **error** — a re-sync would
+fail CI on a file the generator wrote. And PyYAML's preferred single quotes turn
+a Jinja value containing a quote into `== ''influxdb''`, where upstream writes
+`== 'influxdb'`.
+
+Verified by running yamllint with that config over a generated tree: zero
+errors. The `001` layer is a byte copy and carries whatever upstream wrote,
+including the handful of warnings upstream's own files produce.
+
+Not one key or value changes. Once normalized, the generator is idempotent: a
+re-run against its own output reports `exit 0: nothing to do`, and a later
+re-sync touches an existing `010` file by **exactly one line** — the new
+release's pin added to the header.
+
+That difference is worth keeping out of the re-sync diff. Give the transition
+its own commit by running the *current* newest release first:
+
+    tox -e sync-mirror -- --target 2025.2 --base-ref <your branch> ... --apply
+
+Because nothing about the mirror content changes, that run needs no
+dispositions and touches no `001` file — it reports `no value differences` and
+rewrites only the `010` layers. Commit it, then run the real re-sync on top. That
+keeps a wholly cosmetic rewrite of the older layers out of the release diff: in
+the 2026.1 re-sync, its own effect on those layers was one added line each.
+
+## The four classes
+
+Only `semantic` needs anything from you. The other three are reported so that a
+later surprise is traceable, not because there is a decision to make.
+
+### semantic
+
+The value's meaning changed and no rule explains it. Each key blocks `--apply`
+until it carries a disposition. The report names the upstream commit responsible:
+
+    enable_placement: '{{ enable_nova | bool or enable_zun | bool }}' -> '{{ enable_nova | bool }}'
+        upstream: 9f1256ba7 Drop zun and kuryr
+
+### notation
+
+Identical Jinja once whitespace adjacent to `{{ }}` and `{% %}` is collapsed —
+`{% if a %}` versus `{%if a %}`. This is the one class that is **provably**
+inert: the values are normalized and compared, so equality is demonstrated
+rather than assumed.
+
+### representation
+
+A bool-ish token whose truth value did not change. Two kinds occur:
+
+- a **type** change — `'no'` (string) becomes `False` (bool), because upstream
+  rewrote the token and YAML now parses it as a boolean;
+- a **spelling** change — a different token from the same truth set, since
+  `no`/`false`/`off` and `yes`/`true`/`on` are all accepted.
+
+The 2026.1 re-sync was 88 × `'no' -> False` and 13 × `'yes' -> True`, from
+`78f3c2b5d ansible-lint: Remove yaml[truthy] from excludes`.
+
+Unlike `notation`, this is **not proven** inert. A consumer that reads the raw
+value rather than passing it through `| bool` sees `"no"` versus `"False"`. It is
+very likely harmless, and sync-mirror cannot demonstrate that it is — so it says
+so instead of claiming otherwise.
+
+**There is nothing to do about it.** The `001` layer is a byte copy, so the tool
+cannot rewrite `False` back to `'no'` even if you wanted it to; upstream's
+spelling is carried as-is. The class exists so that if a template breaks later,
+you can see which keys changed spelling and in which re-sync.
+
+### overridden
+
+An OSISM layer that applies unconditionally already supplies the key, so the
+upstream change cannot reach a deployment. Judged by lexical position after the
+mirror prefix, not by a hard-coded name; `010-*` is excluded because it is
+release-scoped, and a layer whose value branches on the release does not count as
+unconditional.
+
+    overridden (13) - carried through, no decision needed
+      supplied unconditionally by all/099-kolla.yml (12): ...
+      supplied unconditionally by versions.yml (1): openstack_release
+
+## Dispositions
+
+A semantic key takes exactly one of three flags; giving a key two is an error.
+
+- **`--accept-upstream KEY`** — take the new value for every supported release.
+  Nothing to check.
+- **`--retain KEY`** — keep the OSISM value. The `099` gate is **verified**: it
+  must exist, and carry the right value on the right release.
+- **`--retain-unverified KEY`** — keep the OSISM value where the gate exists but
+  cannot be parsed. Records your acknowledgement and **verifies nothing**.
+
+`--retain` does not write anything. Retention is expressed as a **gate**: a
+value in `099-kolla.yml` that branches on the release, so the older releases keep
+the old value while the target gets the new one. `--retain` is checkable for one
+shape:
+
+    {{ <old> if openstack_version in [<release>, ...] else <new> }}
+
+The parser binds the `in`-branch to the old value and the `else`-branch to the
+new one, so a reversed gate — new value for the older releases — is caught rather
+than accepted. Other forms are legitimate but not parseable: compound
+conditions, `not in`, nested ternaries, variable branches. Those take
+`--retain-unverified`.
+
+A gate is not the same as the `overridden` class above. That class is for a key
+an OSISM layer supplies *unconditionally*, which needs no decision because the
+upstream change cannot reach a deployment. A gate is conditional by definition,
+so its key still comes out `semantic` and still needs a disposition.
+
+So `--retain KEY` means *you add the gate, commit it, then re-run*, and
+sync-mirror confirms it is really there. The commit is not optional: the plan is
+computed from a worktree of `--base-ref`, so an uncommitted gate is invisible:
+
+    $ tox -e sync-mirror -- ... --retain om_rabbitmq_qos_prefetch_count
+    om_rabbitmq_qos_prefetch_count: no later layer supplies it, so nothing
+    retains the old value for the older releases
+    # exit 3
+
+A `--retain` that only recorded intent would let a re-sync report "all
+dispositioned" while the old value silently vanished.
+
+Use `--retain-unverified` only after reading the gate yourself. It is for a gate
+whose shape the validator cannot parse — not for a gate you have not written.
+
+## The generator marker
+
+Every `010-*.yml` sync-mirror writes carries `# generated-by: sync-mirror` as
+line 2 of a fixed header. Before overwriting or deleting an existing `010` file,
+the tool checks the first five lines for that marker and refuses without it:
+
+    --apply is blocked until these are resolved:
+      all/010-2024.1.yml lacks the generator marker
+      (add the '# generated-by: sync-mirror' header line, or let sync-mirror
+       create the file)
+
+This is self-sustaining rather than an ongoing tax: files the tool creates are
+marked automatically, and a file that does not exist yet is written freely. Only
+a **pre-existing, unmarked** file blocks — a layer written by hand, or restored
+from a branch that predates the generator.
+
+## Verifying a synced tree
+
+After `--apply`, the report prints a `check-drift` invocation with the paths
+filled in. It prepends the worktree's parent to your `--base-dir` list, because
+`check-drift` resolves a repo to the first root containing a directory of that
+name — with your own checkout first it would measure the unsynced tree and pass
+on nothing.
+
+**One caveat.** `check-drift` derives its release range by globbing
+`latest/openstack-*.yml` and anchors on the newest, with no flag to narrow it. So
+if a release newer than the one you just synced is already declared, that command
+measures *the newer release*, and its count says nothing about your re-sync.
+The report prints this warning itself when it applies, and names the
+`releases:` config override to measure your target instead.
+
+## Deliberately out of scope
+
+- **`099` edits.** Every semantic decision is named by a human; the tool
+  verifies, never authors.
+- **`002-images-*`.** A separate concern.
+- **Pushing, opening a PR.** `--apply` writes a working tree; `--commit`
+  commits it in that worktree on request, and stops there.
+
+## Module map
+
+| File | Responsibility |
+| ------ | ---------------- |
+| `src/sync-mirror.py` | CLI, disposition validation, emit |
+| `mirror_sync/__init__.py` | `build_plan()` — ties the pieces into one `Plan` |
+| `mirror_sync/model.py` | `Plan`, `Row`, `SyncOpts`; no I/O |
+| `mirror_sync/layers.py` | the `001` byte copy and the `010` key emit |
+| `mirror_sync/effective.py` | release range, commit pinning, `--pins-from` |
+| `mirror_sync/classify.py` | the four classes |
+| `mirror_sync/attribute.py` | upstream commit behind a semantic change |
+| `mirror_sync/gate.py` | `099` retention-gate validation |
+| `mirror_sync/render.py` | terminal report, exit code, JSON payload |
+| `mirror_sync/detail.py` | the full per-key report file |
+| `mirror_sync/worktree.py` | throwaway worktree lifecycle |
+| `mirror_sync/write.py` | applying a `Plan` |
+| `mirror_sync/commit.py` | committing an applied `Plan` (`--commit`) |
+
+Tests live in `tests/mirror_sync/`. Run them with `tox -e drift-test`.

--- a/src/osism_drift/drift/kolla_mirror_verbatim.py
+++ b/src/osism_drift/drift/kolla_mirror_verbatim.py
@@ -3,7 +3,7 @@
 osism/defaults all/001-*.yml files together form a VERBATIM copy of upstream
 kolla-ansible group_vars/all at the newest supported release; every OSISM opinion
 lives in a 099-* file. Nothing enforced that, so 001 drifts (it currently carries
-keys upstream dropped in 2025.2). This is the enforcement arm of Convention X: it
+keys upstream dropped in 2025.2). This is the enforcement side of Convention X: it
 flags every way the 001 layer deviates from upstream-newest and, for each deviation,
 prints the exact destination to move the key to. It never tells anyone to allowlist
 a group_var (Convention X forbids it).

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -235,6 +235,17 @@ def _upstream_groupvars_bodies(release, config) -> list:
     return [body for _, body in _upstream_groupvars_named_bodies(release, config)]
 
 
+def upstream_groupvars_files(release, config) -> list:
+    """[(filename, bytes)] of upstream group_vars/all at `release`.
+
+    Public face of _upstream_groupvars_named_bodies for sync-mirror, which needs
+    the raw bytes and their names to write a verbatim per-service mirror. Reads at
+    whatever release_to_ref() resolves, so a caller that needs a pinned snapshot
+    must pin the ref through config.release_refs first.
+    """
+    return _upstream_groupvars_named_bodies(release, config)
+
+
 def upstream_groupvars_homes(release, config) -> dict:
     """{key: upstream filename} at `release`, lexically-last file winning.
 
@@ -345,6 +356,7 @@ def upstream_groupvars_values(release, config) -> dict:
 
 
 _MIRROR_PREFIX = "001-"
+MIRROR_PREFIX = _MIRROR_PREFIX  # public: sync-mirror builds filenames from it
 
 # User-facing label for the mirror layer. One definition, so the plugin that
 # routes keys into the layer and the plugin that reports on it cannot disagree
@@ -381,25 +393,38 @@ def osism_mirror_values(config) -> dict:
     )
 
 
-def osism_supply_excluding_mirror(config) -> set:
-    """Top-level keys OSISM supplies from every layer EXCEPT the 001-* mirror
-    layer — the other all/*.yml files + the rendered versions.yml.j2 + the
-    per-release overlays.
+def osism_supply_excluding(config, skip_prefixes=(_MIRROR_PREFIX,)) -> set:
+    """Top-level keys OSISM supplies from every all/*.yml layer whose basename does
+    not start with one of `skip_prefixes`, plus the rendered versions.yml.j2 and
+    the per-release overlays.
 
-    Same three-path logic as osism_groupvars_keys, minus the 001 file: lets
-    kolla_mirror_verbatim tell "a 001-only key that another layer already
-    supplies" (delete from 001) from "a 001-only key nothing else supplies"."""
+    Parameterised because two callers need different exclusions: the mirror check
+    wants everything but the 001 layer, while sync-mirror deciding whether a
+    dropped key needs a 010 entry must also exclude the 010 layer itself -- else a
+    key already written there counts as supplied and the layer erases itself on the
+    next run.
+    """
     keys = set()
     for fn in sorted(source.list_dir("defaults", _OSISM_DEFAULTS_DIR, config)):
-        if fn.endswith(".yml") and not fn.startswith(_MIRROR_PREFIX):
-            keys |= top_level_keys(
-                source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
-            )
+        if not fn.endswith(".yml") or fn.startswith(tuple(skip_prefixes)):
+            continue
+        keys |= top_level_keys(
+            source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
+        )
     repo, path = _VERSIONS_TEMPLATE
     keys |= secrets_map.parse_secret_keys(source.read(repo, path, config))
     for body in _osism_overlay_bodies(config):
         keys |= top_level_keys(body)
     return keys
+
+
+def osism_supply_excluding_mirror(config) -> set:
+    """Top-level keys OSISM supplies from every layer EXCEPT the 001-* mirror.
+
+    Lets kolla_mirror_verbatim tell "a 001-only key that another layer already
+    supplies" (delete from 001) from "a 001-only key nothing else supplies".
+    """
+    return osism_supply_excluding(config)
 
 
 def groupvars_home(key, newest, newest_keys, dropped_map, homes=None):

--- a/src/osism_drift/enablement.py
+++ b/src/osism_drift/enablement.py
@@ -309,6 +309,17 @@ def _upstream_groupvars_bodies(release, config) -> list:
     return [body for _, body in _upstream_groupvars_named_bodies(release, config)]
 
 
+def upstream_groupvars_files(release, config) -> list:
+    """[(filename, bytes)] of upstream group_vars/all at `release`.
+
+    Public face of _upstream_groupvars_named_bodies for sync-mirror, which needs
+    the raw bytes and their names to write a verbatim per-service mirror. Reads at
+    whatever release_to_ref() resolves, so a caller that needs a pinned snapshot
+    must pin the ref through config.release_refs first.
+    """
+    return _upstream_groupvars_named_bodies(release, config)
+
+
 def upstream_groupvars_homes(release, config) -> dict:
     """{key: upstream filename} at `release`, lexically-last file winning.
 
@@ -419,6 +430,7 @@ def upstream_groupvars_values(release, config) -> dict:
 
 
 _MIRROR_PREFIX = "001-"
+MIRROR_PREFIX = _MIRROR_PREFIX  # public: sync-mirror builds filenames from it
 
 # User-facing label for the mirror layer. One definition, so the plugin that
 # routes keys into the layer and the plugin that reports on it cannot disagree
@@ -455,25 +467,38 @@ def osism_mirror_values(config) -> dict:
     )
 
 
-def osism_supply_excluding_mirror(config) -> set:
-    """Top-level keys OSISM supplies from every layer EXCEPT the 001-* mirror
-    layer — the other all/*.yml files + the rendered versions.yml.j2 + the
-    per-release overlays.
+def osism_supply_excluding(config, skip_prefixes=(_MIRROR_PREFIX,)) -> set:
+    """Top-level keys OSISM supplies from every all/*.yml layer whose basename does
+    not start with one of `skip_prefixes`, plus the rendered versions.yml.j2 and
+    the per-release overlays.
 
-    Same three-path logic as osism_groupvars_keys, minus the 001 file: lets
-    kolla_mirror_verbatim tell "a 001-only key that another layer already
-    supplies" (delete from 001) from "a 001-only key nothing else supplies"."""
+    Parameterised because two callers need different exclusions: the mirror check
+    wants everything but the 001 layer, while sync-mirror deciding whether a
+    dropped key needs a 010 entry must also exclude the 010 layer itself -- else a
+    key already written there counts as supplied and the layer erases itself on the
+    next run.
+    """
     keys = set()
     for fn in sorted(source.list_dir("defaults", _OSISM_DEFAULTS_DIR, config)):
-        if fn.endswith(".yml") and not fn.startswith(_MIRROR_PREFIX):
-            keys |= top_level_keys(
-                source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
-            )
+        if not fn.endswith(".yml") or fn.startswith(tuple(skip_prefixes)):
+            continue
+        keys |= top_level_keys(
+            source.read("defaults", f"{_OSISM_DEFAULTS_DIR}/{fn}", config)
+        )
     repo, path = _VERSIONS_TEMPLATE
     keys |= secrets_map.parse_secret_keys(source.read(repo, path, config))
     for body in _osism_overlay_bodies(config):
         keys |= top_level_keys(body)
     return keys
+
+
+def osism_supply_excluding_mirror(config) -> set:
+    """Top-level keys OSISM supplies from every layer EXCEPT the 001-* mirror.
+
+    Lets kolla_mirror_verbatim tell "a 001-only key that another layer already
+    supplies" (delete from 001) from "a 001-only key nothing else supplies".
+    """
+    return osism_supply_excluding(config)
 
 
 def groupvars_home(key, newest, newest_keys, dropped_map, homes=None):

--- a/src/osism_drift/mirror_sync/__init__.py
+++ b/src/osism_drift/mirror_sync/__init__.py
@@ -1,0 +1,6 @@
+"""Mirror sync: compute a Plan for a per-release defaults re-sync.
+
+Detection lives in osism_drift.drift; this package is the generation side. One
+pure Plan is computed and then either rendered (report) or written (--apply), so
+the two can never describe different trees.
+"""

--- a/src/osism_drift/mirror_sync/__init__.py
+++ b/src/osism_drift/mirror_sync/__init__.py
@@ -4,3 +4,109 @@ Detection lives in osism_drift.drift; this package is the generation side. One
 pure Plan is computed and then either rendered (report) or written (--apply), so
 the two can never describe different trees.
 """
+
+from osism_drift import enablement, source
+
+from . import layers, attribute, classify, effective, render, worktree  # noqa: F401
+from .model import Plan, Row, SyncOpts  # noqa: F401
+
+_UPSTREAM = "kolla_ansible"
+
+
+def build_plan(config, opts, tree, base_sha) -> Plan:
+    """The one Plan both the renderer and the writer consume.
+
+    `tree` is the worktree; `base_sha` the commit it was created from. Pins are
+    resolved and validated before any content is read, so nothing downstream can
+    pick up a branch tip.
+    """
+    rng = effective.effective_range(config, opts.target)
+    prev = rng[-2] if len(rng) > 1 else None
+
+    tips = effective.resolve_tips(config, rng)
+    shas = effective.requested_shas(opts, rng, tips)
+
+    range_base = None
+    if prev:
+        range_base = source.merge_base(_UPSTREAM, tips[prev], tips[opts.target], config)
+        if range_base is None:
+            # Two stable branches of one repo always share history. No merge base
+            # means something is wrong, and check_pin would silently skip its
+            # lower bound -- the same class of dead check as comparing a pin
+            # against itself.
+            raise source.SourceError(
+                f"no merge base between {prev} and {opts.target}; cannot bound a pin"
+            )
+    effective.check_pin(
+        config, opts.target, shas[opts.target], tips[opts.target], range_base
+    )
+
+    eff = effective.derive(config, opts, tree, shas)
+
+    pre = enablement.osism_mirror_values(eff)
+    m_writes, m_deletes, added_files, deleted_files = layers.mirror_layer(
+        eff, opts.target, tree
+    )
+    post = enablement.groupvars_values(list(m_writes.values()))
+    # The ownership guard protects writes, so it must not abort a read-only
+    # report: blocking there hides the very plan an operator needs in order to
+    # see that a marker commit is required.
+    c_writes, c_deletes, dropped, unowned = layers.compat_layer(
+        eff, rng, shas, tree, strict=opts.apply
+    )
+
+    all_writes = dict(m_writes)
+    all_writes.update(c_writes)
+    changed, created = layers.changed_and_created(all_writes, tree)
+
+    supply = classify.supply_info(eff, tree)
+    # Pre-sync homes come from the mirror ON DISK, not from prev_release. Deriving
+    # them from prev is right only on a first transition: re-run after an upstream
+    # backport on the same target and the on-disk mirror is an earlier commit of
+    # that target. If a key moved files in between, attribution would search the
+    # wrong old path.
+    homes_pre = layers.mirror_homes(tree)
+    homes_post = enablement.upstream_groupvars_homes(opts.target, eff)
+
+    rows = []
+    for key in sorted(set(pre) & set(post)):
+        if pre[key] == post[key]:
+            continue
+        cls, note = classify.classify(key, pre[key], post[key], supply)
+        commits, anote = (), ""
+        if cls == "semantic":
+            homes = sorted({h for h in (homes_pre.get(key), homes_post.get(key)) if h})
+            commits, anote = attribute.commits_for(
+                eff, key, homes, range_base, shas[opts.target]
+            )
+        rows.append(
+            Row(
+                key,
+                pre[key],
+                post[key],
+                cls,
+                commits,
+                "; ".join(x for x in (note, anote) if x),
+            )
+        )
+
+    return Plan(
+        target_release=opts.target,
+        release_shas=shas,
+        defaults_base_sha=base_sha,
+        prev_release=prev,
+        range_base_sha=range_base,
+        mirror_writes=m_writes,
+        mirror_deletes=m_deletes,
+        compat_writes=c_writes,
+        compat_deletes=c_deletes,
+        unowned_compat=unowned,
+        changed_writes=changed,
+        created_paths=created,
+        rows=tuple(rows),
+        added_keys=tuple(sorted(set(post) - set(pre))),
+        dropped_keys=dropped,
+        added_files=added_files,
+        deleted_files=deleted_files,
+        compat_effects=layers.compat_key_effects(c_writes, tree),
+    )

--- a/src/osism_drift/mirror_sync/attribute.py
+++ b/src/osism_drift/mirror_sync/attribute.py
@@ -1,0 +1,79 @@
+"""Upstream commit attribution for a changed key.
+
+The report's most valuable column. On the 2026.1 re-sync, five of the fourteen
+keys flagged "genuinely semantic" traced to one
+`ansible-lint: fix yaml[line-length]` commit, and reading that subject line is
+what made them cheap to dismiss. The classifier cannot decide those keys -- see
+classify.py -- so putting the commit in front of the reviewer is sync-mirror's actual
+contribution, not the classification.
+"""
+
+import re
+import subprocess
+
+from osism_drift import source
+
+_UPSTREAM = "kolla_ansible"
+_GV = "ansible/group_vars/all"
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, check=False
+    )
+
+
+def commits_for(config, key, homes, lo, hi, cap=5):
+    """((\"<abbrev> <subject>\", ...), note) for commits touching `key`.
+
+    One `git log` over every home the key has had, passed as multiple pathspecs.
+    Keys move between upstream files, so searching only the post-sync home would
+    miss the commit that made the change -- but running one log per home and
+    concatenating gets the cap wrong: the results are ordered per home, so with
+    two homes and cap=2 the two newest commits of the *first* home win over a
+    newer commit in the second, while the note claims to show the newest two. A
+    single invocation gives git one globally ordered history and deduplicates a
+    commit touching both files for free. A home that never existed contributes
+    nothing and does not affect the exit status.
+
+    The key is regex-escaped: `git log -G` takes a pattern, so a key carrying
+    regex metacharacters would match unrelated diffs.
+
+    The range is bounded. Unbounded history reports commits from before the branch
+    point that never affected this transition -- including the commit that first
+    introduced the key, which is never the answer to "what changed it".
+
+    `note` is non-empty for every outcome that is not a plain successful list, so
+    the report can never render an empty result that reads like "nothing changed
+    this" when the truth is "this could not be computed".
+    """
+    d = source.local_checkout(_UPSTREAM, config)
+    if d is None:
+        return (), "attribution needs a local checkout of kolla-ansible; skipped"
+    if not lo or not hi:
+        return (), "attribution range could not be established; skipped"
+    paths = [f"{_GV}/{h}" for h in homes if h]
+    if not paths:
+        return (), "no upstream path known for this key; attribution skipped"
+
+    r = _git(
+        d,
+        "log",
+        "--no-merges",
+        "--format=%h %s",
+        "-G",
+        re.escape(key),
+        f"{lo}..{hi}",
+        "--",
+        *paths,
+    )
+    if r.returncode != 0:
+        detail = r.stderr.decode().strip().splitlines()
+        return (), "attribution failed: " + (
+            detail[0] if detail else f"git log exited {r.returncode}"
+        )
+
+    out = [line for line in r.stdout.decode().splitlines() if line]
+    if len(out) > cap:
+        return tuple(out[:cap]), f"truncated to the newest {cap} commits"
+    return tuple(out), ""

--- a/src/osism_drift/mirror_sync/classify.py
+++ b/src/osism_drift/mirror_sync/classify.py
@@ -1,0 +1,155 @@
+"""Classify a changed mirror value: overridden / notation / representation / semantic.
+
+Only `semantic` blocks a write. The other three each exist for a stated reason,
+two of them are narrower than they first appear.
+"""
+
+import re
+from pathlib import Path
+
+from osism_drift import enablement, secrets_map, source
+
+# Explicit, because Python disagrees: bool("no") is True. Never call bool() on a
+# raw value in this module.
+TRUTH = {
+    True: True,
+    "yes": True,
+    "true": True,
+    "on": True,
+    False: False,
+    "no": False,
+    "false": False,
+    "off": False,
+}
+
+_VERSIONS_LAYER = "versions.yml"
+_ALL = "all/"
+_RELEASE_VARS = ("openstack_version", "openstack_release")
+_COND = re.compile(r"\bif\b|\bin\b\s*\[")
+
+
+def _truth(v):
+    """The truth value of a bool-ish token, or None if it is not one."""
+    if isinstance(v, bool):
+        return TRUTH[v]
+    if isinstance(v, str):
+        return TRUTH.get(v.lower())
+    return None
+
+
+def _norm_jinja(s: str) -> str:
+    """Collapse whitespace ADJACENT to Jinja delimiters, and nothing else.
+
+    Reaches `{% if` -> `{%if` and `{{ a }}` -> `{{a}}`, which is the measured
+    difference in the transport_url keys. Deliberately cannot reach inside an
+    expression: collapsing there can alter a string literal, a filter argument or
+    an operator.
+    """
+    s = re.sub(r"\{\{\s+", "{{", s)
+    s = re.sub(r"\s+\}\}", "}}", s)
+    s = re.sub(r"\{%\s+", "{%", s)
+    s = re.sub(r"\s+%\}", "%}", s)
+    return s
+
+
+def _is_release_conditional(value) -> bool:
+    """True if the value branches on the release anywhere inside it.
+
+    Recurses through mappings and sequences rather than testing only strings. A
+    later layer may supply a dict or list whose *nested* value carries the gate,
+    and treating that as unconditional would classify a real per-release change as
+    non-gating -- the exact outcome narrowing `overridden` exists to prevent. No
+    such value exists in the defaults layers today, but 90 non-string values do, so
+    adding a gate inside one is an ordinary edit.
+    """
+    if isinstance(value, str):
+        return any(v in value for v in _RELEASE_VARS) and bool(_COND.search(value))
+    if isinstance(value, dict):
+        return any(
+            _is_release_conditional(k) or _is_release_conditional(v)
+            for k, v in value.items()
+        )
+    if isinstance(value, (list, tuple, set)):
+        return any(_is_release_conditional(v) for v in value)
+    return False
+
+
+def is_unconditional_layer(label: str) -> bool:
+    """True for layers that apply to every deployment unconditionally.
+
+    Judged by lexical position against the mirror prefix, not by a hard-coded
+    prefix: an earlier design tested for "all/0", which silently excluded
+    all/100-ansible.yml -- a real global layer that sorts after the mirror.
+
+    010-* is excluded because it is release-scoped by content, and anything not an
+    all/*.yml file (a per-release overlay, say) is excluded because overlay-only
+    supply proves nothing about the other releases.
+    """
+    if label == _VERSIONS_LAYER:
+        return True
+    if not label.startswith(_ALL) or not label.endswith(".yml"):
+        return False
+    name = label[len(_ALL) :]
+    if name.startswith("010-"):
+        return False
+    return name > enablement.MIRROR_PREFIX
+
+
+def supply_info(config, tree) -> dict:
+    """{key: {"layers": [...], "value": ...}} for keys supplied outside the mirror.
+
+    osism_supply_excluding_mirror() returns a key SET only, which is why
+    membership alone cannot decide `overridden`; the per-layer values are read
+    here.
+
+    The rendered versions.yml layer has to be included or the exception in
+    is_unconditional_layer is unreachable in a real run: an earlier design
+    globbed defaults/all/*.yml only, so openstack_release -- the single key that
+    exception exists for -- came out `semantic`.
+    """
+    info = {}
+    for path in sorted((Path(tree) / "all").glob("*.yml")):
+        if path.name.startswith(enablement.MIRROR_PREFIX):
+            continue
+        for key, value in enablement.groupvars_values([path.read_bytes()]).items():
+            rec = info.setdefault(key, {"layers": [], "value": None})
+            rec["layers"].append(f"{_ALL}{path.name}")
+            rec["value"] = value  # last lexical layer wins, as Ansible does
+
+    # Same source osism_supply_excluding_mirror() uses. Keys only, which is all the
+    # exception needs: it is keyed on the LAYER, not the value. The file is
+    # generated per deployment with openstack_version already bound and sorts after
+    # every 001-* file, so it is unconditional and global by construction.
+    repo, path = enablement._VERSIONS_TEMPLATE
+    for key in secrets_map.parse_secret_keys(source.read(repo, path, config)):
+        rec = info.setdefault(key, {"layers": [], "value": None})
+        rec["layers"].append(_VERSIONS_LAYER)
+    return info
+
+
+def classify(key, old, new, supply):
+    """(class, note) for one key whose parsed value changed."""
+    rec = supply.get(key)
+    if rec:
+        unconditional = [
+            L for L in (rec.get("layers") or []) if is_unconditional_layer(L)
+        ]
+        if unconditional and (
+            _VERSIONS_LAYER in unconditional
+            or not _is_release_conditional(rec.get("value"))
+        ):
+            return "overridden", f"supplied unconditionally by {unconditional[-1]}"
+
+    if isinstance(old, str) and isinstance(new, str):
+        if _norm_jinja(old) == _norm_jinja(new):
+            return "notation", "whitespace adjacent to Jinja delimiters only"
+
+    t_old, t_new = _truth(old), _truth(new)
+    if t_old is not None and t_new is not None and t_old == t_new:
+        return (
+            "representation",
+            "truth value unchanged; only the YAML type or spelling differs "
+            "(see docs/sync-mirror.md)",
+        )
+
+    return "semantic", ""

--- a/src/osism_drift/mirror_sync/commit.py
+++ b/src/osism_drift/mirror_sync/commit.py
@@ -1,0 +1,101 @@
+"""Commit an applied plan inside the worktree, on request.
+
+Only reached through --commit, and only after --apply has written. Every
+judgement the re-sync needs -- the disposition of each semantic value, any 099
+gate -- has been made and validated by then, so what is left is mechanical:
+branch the detached worktree, stage exactly what the plan touched, write a
+message whose provenance the tool already computed.
+
+The branch is not optional. The worktree is detached, so a commit made here
+would be unreferenced the moment the worktree is removed, and the operator would
+be left digging in the reflog for work they were told had been committed.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+class CommitError(Exception):
+    """Any failure while committing; the CLI maps it to exit 3."""
+
+
+class BranchExists(CommitError):
+    """The target branch is already present; refuse rather than move it."""
+
+
+def _git(tree, *args, stdin=None):
+    return subprocess.run(
+        ["git", "-C", str(tree), *args],
+        capture_output=True,
+        check=False,
+        input=stdin.encode() if stdin else None,
+    )
+
+
+def default_branch(target) -> str:
+    return f"sync-mirror/{target}"
+
+
+def signoff(tree) -> str:
+    """`Signed-off-by:` from the repo's git config.
+
+    Without it the eventual PR fails Zuul's DCO gate, so a commit this tool made
+    would be born broken. Passing --commit is the operator asking for the commit,
+    which is the same assertion `git commit -s` makes.
+    """
+    name = _git(tree, "config", "user.name").stdout.decode().strip()
+    email = _git(tree, "config", "user.email").stdout.decode().strip()
+    if not name or not email:
+        raise CommitError(
+            "git config user.name and user.email must be set to sign off a commit"
+        )
+    return f"Signed-off-by: {name} <{email}>"
+
+
+def message(target, provenance, tree) -> str:
+    """Subject, the provenance block, and the sign-off.
+
+    Deliberately not the whole message: why each semantic value was accepted or
+    retained is the reviewer's contribution and no generator can supply it. The
+    caller tells the operator to amend.
+    """
+    subject = f"kolla: re-sync the mirror layer for {target}"
+    return f"{subject}\n\n{provenance.rstrip()}\n\n{signoff(tree)}\n"
+
+
+def commit(tree, branch, target, provenance, paths) -> str:
+    """Branch, stage `paths`, commit. Returns the new commit's sha."""
+    tree = Path(tree)
+    if (
+        _git(
+            tree, "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"
+        ).returncode
+        == 0
+    ):
+        raise BranchExists(
+            f"branch {branch} already exists in {tree}; pass --commit-branch"
+        )
+    r = _git(tree, "switch", "-c", branch)
+    if r.returncode != 0:
+        raise CommitError(f"git switch -c {branch} failed: {_err(r)}")
+
+    # --all so a path the plan deleted is staged as a deletion. Pathspecs, not a
+    # bare `git add -A`: the tree should hold nothing but the plan's writes, and
+    # if it does that is a bug worth surfacing rather than sweeping into the
+    # commit.
+    r = _git(tree, "add", "--all", "--", *sorted(paths))
+    if r.returncode != 0:
+        raise CommitError(f"git add failed: {_err(r)}")
+
+    r = _git(tree, "commit", "-F", "-", stdin=message(target, provenance, tree))
+    if r.returncode != 0:
+        raise CommitError(f"git commit failed: {_err(r)}")
+
+    head = _git(tree, "rev-parse", "HEAD")
+    if head.returncode != 0:
+        raise CommitError("commit succeeded but HEAD did not resolve")
+    return head.stdout.decode().strip()
+
+
+def _err(r) -> str:
+    return r.stderr.decode().strip() or r.stdout.decode().strip() or str(r.returncode)

--- a/src/osism_drift/mirror_sync/detail.py
+++ b/src/osism_drift/mirror_sync/detail.py
@@ -1,0 +1,88 @@
+"""The full per-key report, written to a file rather than the terminal.
+
+The terminal report answers "what do I have to decide"; this answers "what
+exactly changed". They are split because the values that most need reading are
+the ones a terminal renders worst: a re-wrapped Jinja expression is one 1449-char
+line with literal \\n escapes when repr()'d, and no operator reads that.
+
+Multi-line values are therefore emitted with REAL newlines and indented, so a
+re-wrap reads as a re-wrap. Values are the parsed YAML, not the source bytes:
+that is what classification compared, so it is what a disposition is about.
+"""
+
+from .model import SyncOpts
+
+_CLASSES = ("semantic", "notation", "representation", "overridden")
+
+_MEANING = {
+    "semantic": "the meaning changed and no rule explains it; each key needs a "
+    "disposition and blocks --apply until it has one",
+    "notation": "identical Jinja once whitespace adjacent to {{ }} / {% %} is "
+    "collapsed; carried through unchanged",
+    "representation": "a bool-ish token whose truth value did not change "
+    "('no' -> False); the 001 layer is a byte-for-byte mirror, so upstream's "
+    "spelling is carried as-is. See docs/sync-mirror.md",
+    "overridden": "an OSISM layer that applies unconditionally already supplies "
+    "this key, so the upstream change cannot reach a deployment",
+}
+
+
+def _block(value, indent="     ") -> list:
+    """One value, readable: real newlines for multi-line strings, repr otherwise.
+
+    repr() is kept for everything else because quoting matters here -- 'no' and
+    False are the whole point of the representation class, and str() would render
+    them identically.
+    """
+    if isinstance(value, str) and "\n" in value:
+        return [f"{indent}{line}" if line else "" for line in value.split("\n")]
+    return [f"{indent}{value!r}"]
+
+
+def text(plan, opts=None) -> str:
+    """The detail report for one plan."""
+    opts = opts or SyncOpts(target=plan.target_release)
+    out = [
+        "sync-mirror detail report",
+        "",
+        f"target        {plan.target_release} @ "
+        f"{plan.release_shas.get(plan.target_release, '?')}",
+        f"defaults base {opts.base_ref} @ {plan.defaults_base_sha}",
+        "",
+        "Every changed value, in full. The terminal report inlines only short",
+        "single-line values; the rest are here. Values are the parsed YAML.",
+    ]
+
+    for cls in _CLASSES:
+        rows = [r for r in plan.rows if r.cls == cls]
+        if not rows:
+            continue
+        out += ["", "=" * 72, f"{cls} ({len(rows)})", _MEANING[cls], "=" * 72]
+        for r in sorted(rows, key=lambda r: r.key):
+            out += ["", f"-- {r.key}"]
+            for line in r.commits:
+                out.append(f"   upstream: {line}")
+            if r.note:
+                out.append(f"   {r.note}")
+            out += ["", "   mirror (current):"]
+            out += _block(r.old)
+            out += ["", f"   upstream {plan.target_release}:"]
+            out += _block(r.new)
+
+    if plan.added_files or plan.deleted_files:
+        out += ["", "=" * 72, "files", "=" * 72]
+        out += [f"  + {f}" for f in sorted(plan.added_files)]
+        out += [f"  - {f}" for f in sorted(plan.deleted_files)]
+    if plan.added_keys:
+        out += ["", "=" * 72, f"keys added ({len(plan.added_keys)})", "=" * 72]
+        out += [f"  {k}" for k in sorted(plan.added_keys)]
+    if plan.dropped_keys:
+        out += ["", "=" * 72, f"keys dropped ({len(plan.dropped_keys)})", "=" * 72]
+        out += [
+            "the target no longer defines these and no other OSISM layer supplies",
+            "them, so they move into a release-scoped back-compat layer:",
+            "",
+        ]
+        out += [f"  {k} -> {d}" for k, d in sorted(plan.dropped_keys.items())]
+
+    return "\n".join(out) + "\n"

--- a/src/osism_drift/mirror_sync/effective.py
+++ b/src/osism_drift/mirror_sync/effective.py
@@ -1,0 +1,160 @@
+"""Effective release range and commit pinning for one sync run.
+
+Two silent-wrongness cases are contained here, both found by review rather than
+by a failing check:
+
+- dropped_key_release_map() iterates sorted(release_range(config))[:-1], so it
+  derives its own target. Passing the ambient config makes --target decorative
+  and emits 010 data for the wrong release. Everything target-sensitive gets the
+  derived config instead.
+- _local_repo_dir() returns the FIRST --base-dir containing the repo directory,
+  so a plain --base-dir pointing at the operator's checkout would shadow the
+  worktree. The worktree parent is prepended.
+"""
+
+import re
+from dataclasses import replace
+from pathlib import Path
+
+from osism_drift import enablement, source
+
+_UPSTREAM = "kolla_ansible"
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def effective_range(config, target) -> list:
+    """Supported releases up to and including `target`, ascending."""
+    supported = sorted(enablement.release_range(config))
+    if target not in supported:
+        raise ValueError(
+            f"{target!r} is not a supported release; have {', '.join(supported)}"
+        )
+    return supported[: supported.index(target) + 1]
+
+
+def resolve_tips(config, rng) -> dict:
+    """{release: branch-tip commit} for every release in `rng`.
+
+    Resolved BEFORE any user pin is applied. check_pin() needs the real tip as its
+    upper bound; an earlier design validated the pin against a map into which the
+    pin had already been written, so the bound was pin <= pin -- and
+    `git merge-base --is-ancestor X X` exits 0, making the whole check dead code.
+    """
+    return {
+        rel: source.resolve_commit(
+            _UPSTREAM, source.release_to_ref(_UPSTREAM, rel, config), config
+        )
+        for rel in rng
+    }
+
+
+def requested_shas(opts, rng, tips) -> dict:
+    """{release: commit} the run will actually read, pin precedence applied.
+
+    Precedence is an error, never a silent override: --pin and --pins-from may not
+    both name the target.
+    """
+    if opts.pins and opts.pin:
+        raise ValueError(
+            "--pin and --pins-from both supplied; pass one (--pins-from already "
+            "carries the target's commit)"
+        )
+    shas = dict(tips)
+    if opts.pins:
+        shas.update(opts.pins)
+    elif opts.pin:
+        shas[opts.target] = opts.pin
+    for rel, sha in shas.items():
+        if not _SHA40.match(str(sha)):
+            raise ValueError(f"pin for release {rel!r} is not a 40-hex commit: {sha!r}")
+    return shas
+
+
+def validate_pins_payload(payload, target, rng) -> tuple:
+    """({release: sha}, defaults_base_sha) from a --pins-from report.
+
+    A replay file decides what the acceptance test compares, so every mismatch is
+    an error rather than a best-effort merge.
+    """
+    if payload.get("schema") != 1:
+        raise ValueError(f"--pins-from: unsupported schema {payload.get('schema')!r}")
+    if payload.get("target_release") != target:
+        raise ValueError(
+            f"--pins-from was produced for target {payload.get('target_release')!r}, "
+            f"not {target!r}"
+        )
+    shas = payload.get("release_shas") or {}
+    if not isinstance(shas, dict):
+        raise ValueError("--pins-from: release_shas is not a mapping")
+    want, have = set(rng), set(shas)
+    if want != have:
+        raise ValueError(
+            f"--pins-from release set {sorted(have)} does not match the effective "
+            f"range {sorted(want)}"
+        )
+    for rel in sorted(shas):
+        if not _SHA40.match(str(shas[rel])):
+            raise ValueError(
+                f"--pins-from: release {rel!r} sha {shas[rel]!r} is not a 40-hex "
+                "commit"
+            )
+    base = payload.get("defaults_base_sha")
+    if not base or not _SHA40.match(str(base)):
+        raise ValueError("--pins-from has no usable defaults_base_sha")
+    return shas, base
+
+
+def derive(config, opts, defaults_tree, shas):
+    """Effective Config for this run, given already-validated `shas`.
+
+    Pins every release in the effective range to a commit, so no downstream reader
+    can pick up a branch tip, and resolves `defaults` to `defaults_tree`.
+    """
+    rng = effective_range(config, opts.target)
+
+    refs = {k: dict(v) for k, v in (config.release_refs or {}).items()}
+    refs.setdefault(_UPSTREAM, {}).update(shas)
+
+    parent = str(Path(defaults_tree).parent)
+    base_dirs = (parent,) + tuple(d for d in config.base_dirs if d != parent)
+
+    return replace(
+        config,
+        releases=tuple(rng),
+        release_refs=refs,
+        base_dirs=base_dirs,
+        # Fresh per-run state. Sharing these would let a memo taken against an
+        # unpinned ref satisfy a pinned read.
+        ref_cache={},
+        groupvars_cache={},
+        snapshot_cache={},
+    )
+
+
+def check_pin(config, target, pin, tip, range_base_sha) -> None:
+    """Bound the effective target commit to the target-side history.
+
+    Validated whatever its origin -- --pin, --pins-from, or automatic resolution.
+    An earlier design returned early unless --pin was given, so a --pins-from
+    replay trusted every supplied commit unchecked.
+
+    `tip` must be the real branch tip, resolved before the pin was applied.
+    Ancestor-of-tip alone is also too weak: every commit before the release
+    branched is an ancestor, including one from an earlier series with a different
+    group_vars layout.
+    """
+    if pin == tip:
+        return  # nothing was overridden
+    if not source.is_ancestor(_UPSTREAM, pin, tip, config):
+        raise source.SourceError(
+            f"pin {pin[:12]} is not reachable from the {target} tip {tip[:12]}"
+        )
+    if range_base_sha is None:
+        # Single-release range: no branch point to bound against. The report says
+        # which check ran.
+        return
+    if not source.is_ancestor(_UPSTREAM, range_base_sha, pin, config):
+        raise source.SourceError(
+            f"pin {pin[:12]} is before the branch point {range_base_sha[:12]}; "
+            f"not a snapshot of {target}"
+        )

--- a/src/osism_drift/mirror_sync/gate.py
+++ b/src/osism_drift/mirror_sync/gate.py
@@ -1,0 +1,191 @@
+"""Disposition validation for semantic rows.
+
+--accept-upstream needs nothing checked. --retain claims a 099 release gate keeps
+the old value for the older releases, and that claim is checkable for one shape:
+
+    {{ <old-literal> if openstack_version in [<release>, ...] else <new-literal> }}
+
+Association matters. Requiring only that the old value, the new value and the
+release names each APPEAR somewhere is satisfied by a reversed gate -- new value
+for the older releases, old value for the target -- so the parser binds the
+in-branch literal to the old value and the else-branch to the new one.
+
+There is no jinja2 dependency, and adding one to parse arbitrary gates would be
+the wrong trade: real gates include compound conditions, `not in`, nested
+ternaries and variable branches (099-kolla.yml lines 103 and 233). Those are
+legitimate and simply not parseable, so they take --retain-unverified and the
+report says sync-mirror checked nothing.
+"""
+
+import re
+
+import yaml
+
+from . import classify
+
+_LIT = r"(?:'[^']*'|\"[^\"]*\")"
+# Every list item must be a quoted literal. Accepting arbitrary contents lets a
+# mixed list such as ['2024.1', 2024.2] through, where YAML yields a str and a
+# float and a later sorted() raises TypeError -- a traceback and exit 1 instead of
+# a controlled refusal.
+_LIST = rf"{_LIT}(?:\s*,\s*{_LIT})*\s*,?"
+CANONICAL = re.compile(
+    r"^\{\{\s*"
+    rf"(?P<old>{_LIT})"
+    r"\s+if\s+(?:openstack_version|openstack_release)\s+in\s*\[\s*"
+    rf"(?P<releases>{_LIST})"
+    r"\s*\]\s+else\s+"
+    rf"(?P<new>{_LIT})"
+    r"\s*\}\}$"
+)
+
+
+class GateError(Exception):
+    """Base: one except clause covers every disposition refusal."""
+
+
+class NotCanonical(GateError):
+    """The gate exists but this parser cannot read it."""
+
+
+class GateMismatch(GateError):
+    """The gate is canonical and says the wrong thing, or there is no gate."""
+
+
+class UnknownDisposition(GateError):
+    """A disposition names a key that is not a semantic row in this plan."""
+
+
+class WrongDisposition(GateError):
+    """A canonical gate was passed through the acknowledgement flag."""
+
+
+def _lit(text):
+    return yaml.safe_load(text)
+
+
+def parse_gate(value):
+    """{"old", "new", "releases"} for a canonical gate, else None."""
+    if not isinstance(value, str):
+        return None
+    m = CANONICAL.match(" ".join(value.split()))
+    if not m:
+        return None
+    rels = [_lit(r.strip()) for r in m.group("releases").split(",") if r.strip()]
+    # Belt and braces: the regex already admits only quoted literals, but a
+    # non-string here would reach sorted() alongside strings and raise TypeError
+    # rather than producing a refusal the operator can act on.
+    if not all(isinstance(r, str) for r in rels):
+        return None
+    return {
+        "old": _lit(m.group("old")),
+        "new": _lit(m.group("new")),
+        "releases": rels,
+    }
+
+
+def _gate_layer(supply, key):
+    """(record, layer) for the later, non-010 layer supplying `key`.
+
+    010-* sorts before 099-*, so a gate there cannot retain a changed value -- the
+    mirror's new value would win for every release.
+    """
+    rec = supply.get(key) or {}
+    layers = [
+        L
+        for L in (rec.get("layers") or [])
+        if classify.is_unconditional_layer(L) or L.startswith("all/099-")
+    ]
+    return (rec, layers[-1]) if layers else (rec, None)
+
+
+def check_retain(key, old, new, supply, older):
+    """Return a note, or raise. `older` is the releases that must keep `old`."""
+    rec, layer = _gate_layer(supply, key)
+    if layer is None:
+        raise GateMismatch(
+            f"{key}: no later layer supplies it, so nothing retains the old value "
+            "for the older releases"
+        )
+    g = parse_gate(rec.get("value"))
+    if g is None:
+        raise NotCanonical(
+            f"{key}: the gate in {layer} is not in the canonical "
+            "'<old> if openstack_version in [...] else <new>' shape; sync-mirror "
+            "cannot verify it -- pass --retain-unverified to record an "
+            "acknowledgement instead"
+        )
+    if g["old"] != old or g["new"] != new:
+        raise GateMismatch(
+            f"{key}: the gate in {layer} binds the wrong values -- its in-branch "
+            f"yields {g['old']!r} and its else yields {g['new']!r}, but the mirror "
+            f"changes {old!r} -> {new!r}"
+        )
+    if sorted(g["releases"]) != sorted(older):
+        raise GateMismatch(
+            f"{key}: the gate in {layer} lists releases {sorted(g['releases'])}, "
+            f"but the releases needing the old value are {sorted(older)}"
+        )
+    return f"verified against the canonical gate in {layer}"
+
+
+def missing_dispositions(plan, opts) -> list:
+    """Semantic keys carrying no disposition flag at all, in row order.
+
+    Deliberately does no validation: a bad disposition is an operational failure
+    with its own diagnostic, not a row that merely still needs one. Flattening the
+    two produces a generic "needs a disposition" for a gate that was supplied and
+    wrong, which tells the operator nothing about what to fix.
+    """
+    given = set(opts.accept_upstream) | set(opts.retain) | set(opts.retain_unverified)
+    return [r.key for r in plan.rows if r.cls == "semantic" and r.key not in given]
+
+
+def validate_dispositions(plan, opts, older, supply) -> dict:
+    """{key: note} for dispositions that pass. Raises on any that do not.
+
+    Three failures are operational, not "still needs review":
+
+    - a disposition naming a key that is not a semantic row here. A stale flag
+      from a previous re-sync would otherwise pass silently and read as though a
+      decision had been recorded for something.
+    - --retain whose gate does not bind the right values to the right branches, or
+      names the wrong releases. The diagnostic is the whole value of the check.
+    - --retain-unverified for a gate this parser CAN bind, or for a key with no
+      gate at all. The first records "unchecked" for something checkable; the
+      second acknowledges nothing while --apply would change the value for every
+      release.
+    """
+    semantic = {r.key: r for r in plan.rows if r.cls == "semantic"}
+    for flag, keys in (
+        ("--accept-upstream", opts.accept_upstream),
+        ("--retain", opts.retain),
+        ("--retain-unverified", opts.retain_unverified),
+    ):
+        for key in sorted(set(keys) - set(semantic)):
+            raise UnknownDisposition(
+                f"{flag} {key}: not a semantic row in this plan -- a stale flag "
+                "from an earlier re-sync, or a typo"
+            )
+
+    notes = {}
+    for key in sorted(opts.retain):
+        row = semantic[key]
+        notes[key] = check_retain(key, row.old, row.new, supply, older)
+    for key in sorted(opts.retain_unverified):
+        rec, layer = _gate_layer(supply, key)
+        if layer is None:
+            raise GateMismatch(
+                f"--retain-unverified {key}: no later layer supplies it, so there "
+                "is no gate to acknowledge -- nothing retains the old value for "
+                "the older releases"
+            )
+        if parse_gate(rec.get("value")) is not None:
+            raise WrongDisposition(
+                f"--retain-unverified {key}: the gate in {layer} is canonical and "
+                "can be verified -- use --retain"
+            )
+        notes[key] = f"acknowledged; gate in {layer} is not in the canonical shape"
+    for key in sorted(opts.accept_upstream):
+        notes[key] = "upstream value accepted for every supported release"
+    return notes

--- a/src/osism_drift/mirror_sync/layers.py
+++ b/src/osism_drift/mirror_sync/layers.py
@@ -1,0 +1,347 @@
+"""The two generated layers: the 001 byte-copy mirror and the 010 back-compat emit.
+
+Both compute desired state only. Nothing here touches the filesystem except to
+read it for comparison; the writer consumes the resulting Plan.
+
+The report is deliberately NOT here: classification lives in classify.py,
+upstream attribution in attribute.py, and rendering in render.py/detail.py.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from osism_drift import enablement
+
+_ALL = "all"
+_PREFIX = enablement.MIRROR_PREFIX  # "001-"
+_MARKER = "generated-by: sync-mirror"
+_MARKER_LINE = f"# {_MARKER}"
+_MARKER_SCAN_LINES = 5  # header only; a marker further down is not ownership
+
+
+class LayerError(Exception):
+    """Base for every refusal in this module, so one except clause covers them."""
+
+
+class MonolithicLayout(LayerError):
+    """Upstream ships one group_vars/all.yml (<=2025.1); the 001 mirror layer needs the split."""
+
+
+class EmptyUpstreamLayer(LayerError):
+    """Upstream listed no group_vars files; deleting the whole mirror is not a plan."""
+
+
+class UnownedCompatFile(LayerError):
+    """A managed 010-* file lacks the generator marker; refuse to touch it."""
+
+
+def _safe_name(name: str) -> str:
+    """Confine an upstream basename before it becomes a write path.
+
+    Upstream names come from a non-recursive git tree listing, so separators cannot
+    appear today. This guards our own code: if that listing is ever made recursive,
+    a 'subdir/foo.yml' would write outside the intended set silently.
+    """
+    if name != Path(name).name or not name.endswith(".yml"):
+        raise ValueError(f"upstream group_vars name {name!r} is not a bare basename")
+    return name
+
+
+def mirror_layer(config, target, tree):
+    """(writes, deletes, added_files, deleted_files) for the 001 layer.
+
+    The 001- prefix is a constant, never a parameter. all/ merges in lexical
+    filename order with later files winning, and 64 keys in the mirror are
+    deliberately overridden by later OSISM files; a copy named nova.yml would sort
+    after every digit-prefixed file and silently reverse all of them.
+    """
+    files = enablement.upstream_groupvars_files(target, config)
+    names = [_safe_name(n) for n, _ in files]
+    if not names:
+        # Every existing 001-* file would have no upstream counterpart, so the plan
+        # would be "delete the entire mirror, write nothing". A vanished listing is
+        # far likelier than upstream genuinely shipping no group_vars -- a renamed
+        # path or a bad ref reaches here as an empty list.
+        raise EmptyUpstreamLayer(
+            f"upstream {target} listed no group_vars/all files; refusing to plan "
+            "deletion of the whole mirror layer"
+        )
+    if names == ["all.yml"]:
+        raise MonolithicLayout(
+            f"upstream {target} ships a monolithic group_vars/all.yml; "
+            "sync-mirror supports the per-service layout only"
+        )
+
+    writes = {
+        f"{_ALL}/{_PREFIX}{n}": body for n, body in zip(names, [b for _, b in files])
+    }
+    upstream_names = set(names)
+
+    existing = sorted(
+        p.name for p in (Path(tree) / _ALL).glob(f"{_PREFIX}*.yml") if p.is_file()
+    )
+    deletes = tuple(
+        f"{_ALL}/{fn}" for fn in existing if fn[len(_PREFIX) :] not in upstream_names
+    )
+    added = tuple(sorted(p for p in writes if Path(p).name not in existing))
+    return writes, deletes, added, deletes
+
+
+def mirror_homes(tree) -> dict:
+    """{key: upstream basename} for the mirror layer as it exists on disk now.
+
+    Lexically last file wins, matching how Ansible loads a group_vars directory,
+    so the file named is the one whose value actually takes effect. The 001-
+    prefix is stripped so these line up with upstream_groupvars_homes().
+
+    Read from disk rather than inferred from the previous release: re-run sync-mirror
+    after an upstream backport on the same target and the on-disk mirror is an
+    earlier commit of that target, not of prev.
+    """
+    homes = {}
+    for path in sorted((Path(tree) / _ALL).glob(f"{_PREFIX}*.yml")):
+        for key in enablement.groupvars_values([path.read_bytes()]):
+            homes[key] = path.name[len(_PREFIX) :]
+    return homes
+
+
+def compat_layer(config, rng, shas, tree, strict=True):
+    """(writes, deletes, {key: destination}) for the 010 back-compat layer.
+
+    Keys come from dropped_key_release_map, at key granularity: of the 31 keys
+    dropped between 2025.2 and 2026.1, three came from files that still exist, so
+    a whole-file carry would miss exactly those. Values come from the newest
+    release that still defines the key.
+
+    Only releases in rng[:-1] are managed. Without that scoping a replay with an
+    older --target would find no keys for a later re-sync's 010 file and delete
+    it; files outside the set are never written, deleted, or even inspected.
+    """
+    target = rng[-1]
+    managed = set(rng[:-1])
+    # dropped_key_release_map() is NOT a map of dropped keys: it maps EVERY key
+    # defined by a release below the newest to the newest such release. A key is
+    # dropped only if the target no longer defines it -- which is how
+    # groupvars_home() reads it, checking `key in newest_keys` first and consulting
+    # the map only on the way past. Using the map directly emitted 880 keys for a
+    # 2025.2 target where 31 were dropped.
+    still_defined = enablement.upstream_groupvars_keys(target, config)
+    # A dropped key that another OSISM layer already supplies needs no 010 entry:
+    # the enforced union is satisfied, and 010-* sorts before 099-* so the entry
+    # would be shadowed anyway. Validated against ground truth -- without this the
+    # generator emitted 37 keys the committed files omit, and all 37 were supplied
+    # by a 099 layer.
+    #
+    # osism_supply_excluding_mirror() cannot serve here: it excludes the 001 mirror
+    # but INCLUDES the 010 layer, so every key already present in a committed 010
+    # file reads as "supplied" and the generator empties its own output.
+    supplied = enablement.osism_supply_excluding(config, (_PREFIX, "010-"))
+    by_release = {}
+    for key, rel in enablement.dropped_key_release_map(config).items():
+        if rel in managed and key not in still_defined and key not in supplied:
+            by_release.setdefault(rel, []).append(key)
+
+    writes, dests, unowned = {}, {}, []
+    for rel, keys in by_release.items():
+        values = enablement.upstream_groupvars_values(rel, config)
+        missing = [k for k in keys if k not in values]
+        if missing:
+            raise KeyError(
+                f"dropped keys {sorted(missing)} have no value at release {rel}; "
+                "dropped_key_release_map and upstream_groupvars_values disagree"
+            )
+        path = f"{_ALL}/010-{rel}.yml"
+        if not _owned(tree, path):
+            unowned.append(path)
+            if strict:
+                _refuse(path)
+        writes[path] = _render_compat(rel, keys, values, shas)
+        for k in keys:
+            dests[k] = path
+
+    # An existing managed file with no desired keys is stale and must go, or the
+    # layer keeps supplying keys upstream has since restored.
+    deletes = []
+    for rel in sorted(managed):
+        path = f"{_ALL}/010-{rel}.yml"
+        if path in writes:
+            continue
+        if (Path(tree) / path).exists():
+            if not _owned(tree, path):
+                unowned.append(path)
+                if strict:
+                    _refuse(path)
+            deletes.append(path)
+    return writes, tuple(deletes), dests, tuple(sorted(set(unowned)))
+
+
+def _owned(tree, path) -> bool:
+    """True if we may write or delete this 010 file.
+
+    An absent file is ours to create. An existing one must carry an exact marker
+    line in its header -- not a substring anywhere, because a hand-written file
+    could legitimately mention the marker in a value or a comment.
+    """
+    f = Path(tree) / path
+    if not f.exists():
+        return True
+    head = f.read_text(encoding="utf-8").splitlines()[:_MARKER_SCAN_LINES]
+    return any(line.strip() == _MARKER_LINE for line in head)
+
+
+def _refuse(path):
+    raise UnownedCompatFile(
+        f"{path} has no '{_MARKER_LINE}' header line; refusing to overwrite or "
+        "delete a file this tool did not generate"
+    )
+
+
+class _IndentedDumper(yaml.SafeDumper):
+    """SafeDumper that indents block sequences under their key.
+
+    yaml.safe_dump emits a block sequence at the PARENT's indentation:
+
+        run_default_subdirectories:
+        - /run/netns
+
+    osism/defaults runs yamllint with `extends: default`, whose
+    indentation rule sets indent-sequences: true, so that form is an error --
+    a re-sync would fail CI on a file this generator wrote. The hand-written
+    layers were indented; the generated ones have to be too.
+    """
+
+    def increase_indent(self, flow=False, indentless=False):
+        # indentless=True is what drops the sequence indentation. Never honour it.
+        return super().increase_indent(flow, False)
+
+
+def _double_quoted_str(dumper, value):
+    """Emit every string double-quoted, the way upstream and the hand-written
+    layers do.
+
+    PyYAML's default prefers single quotes, which inverted the house style in
+    this directory: the 001 mirror carries 677 double-quoted values and no
+    single-quoted ones, and the hand-maintained 010 layers matched it. Worse, a
+    Jinja value containing a single quote came out with YAML's doubling escape --
+    "== ''influxdb''" -- where upstream writes "== 'influxdb'".
+
+    No value in the layer contains a double quote, so forcing this style needs no
+    escaping; multi-line strings would fold awkwardly, and none occur here
+    because the 010 layers carry values from releases that predate upstream's
+    re-wrap.
+    """
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style='"')
+
+
+class _BareKey(str):
+    """A mapping key, emitted unquoted.
+
+    The double-quoted style above applies to every str, keys included, and
+    upstream writes bare keys with quoted values -- `enable_nova: "{{ ... }}"`.
+    Marking the keys is less invasive than reimplementing represent_mapping to
+    tell one from the other.
+    """
+
+
+def _bare_key(dumper, value):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(value), style=None)
+
+
+def _mark_keys(value):
+    """Mark every mapping key, at any depth, as bare.
+
+    Nested keys are as bare as top-level ones upstream -- a container's
+    `ulimits: {nofile: {soft: ...}}` has no quotes at any level -- so marking
+    only the outer dict left the inner ones quoted.
+    """
+    if isinstance(value, dict):
+        return {
+            (_BareKey(k) if isinstance(k, str) else k): _mark_keys(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_mark_keys(v) for v in value]
+    return value
+
+
+_IndentedDumper.add_representer(str, _double_quoted_str)
+_IndentedDumper.add_representer(_BareKey, _bare_key)
+
+
+def _render_compat(rel, keys, values, shas) -> str:
+    """Generator-owned 010 file: fixed header, sorted keys, one document.
+
+    Values ARE re-serialized here, unlike the 001 layer. That is safe and
+    deliberate: kolla_mirror_verbatim enforces verbatim on the 001 layer only, and
+    010-* is OSISM-authored back-compat rather than a mirror. The header says so,
+    so nobody "fixes" the notation later.
+    """
+    head = [
+        "---",
+        _MARKER_LINE,
+        f"# Self-retiring backward-compat layer for release {rel}.",
+        "#",
+        "# Upstream group_vars/all keys that a newer supported release dropped but",
+        f"# that release {rel} still defines. Loads between the 001-* mirror and",
+        "# 099 (OSISM opinions). Values are re-serialized, not byte-copied:",
+        "# verbatim is enforced on the 001 layer only. No OSISM edits belong here.",
+        "#",
+        f"# Remove this file when {rel} leaves the supported release range.",
+        "# Source: openstack/kolla-ansible ansible/group_vars/all, at the pinned",
+        "# commit for each supported release in this run:",
+    ] + [f"#   {r}: {shas[r]}" for r in sorted(shas)]
+    # sort_keys=False, with the top level sorted explicitly above: sorting every
+    # level would reorder a nested mapping away from the order upstream wrote it
+    # in -- a container's ulimits came out hard-before-soft -- for no gain, since
+    # determinism only needs the top level fixed.
+    body = yaml.dump(
+        _mark_keys({k: values[k] for k in sorted(keys)}),
+        Dumper=_IndentedDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        width=1000,
+    )
+    return "\n".join(head) + "\n" + body
+
+
+def compat_key_effects(writes, tree):
+    """{path: {"added": [...], "removed": [...], "updated": [...]}} per 010 layer.
+
+    A byte comparison can only say "differs", and a 010 file differs on every run
+    because its header carries the pinned commit of each release in range. Saying
+    "rewritten" for a file whose keys and values are untouched reads as data loss.
+    So compare the parsed bodies and report what actually moves -- usually
+    nothing.
+    """
+    effects = {}
+    for path, desired in sorted(writes.items()):
+        on_disk = Path(tree) / path
+        if not on_disk.exists():
+            continue
+        old = yaml.safe_load(on_disk.read_text(encoding="utf-8")) or {}
+        new = yaml.safe_load(desired) or {}
+        effects[path] = {
+            "added": sorted(set(new) - set(old)),
+            "removed": sorted(set(old) - set(new)),
+            "updated": sorted(k for k in set(old) & set(new) if old[k] != new[k]),
+        }
+    return effects
+
+
+def changed_and_created(writes, tree):
+    """(changed_writes, created_paths) by byte comparison against `tree`.
+
+    has_changes must come from this, not from writes being non-empty: writes is
+    the full desired layer and always holds every unchanged file too.
+    """
+    changed, created = [], []
+    for path, desired in sorted(writes.items()):
+        on_disk = Path(tree) / path
+        want = desired if isinstance(desired, bytes) else desired.encode()
+        if not on_disk.exists():
+            changed.append(path)
+            created.append(path)
+        elif on_disk.read_bytes() != want:
+            changed.append(path)
+    return tuple(changed), tuple(created)

--- a/src/osism_drift/mirror_sync/model.py
+++ b/src/osism_drift/mirror_sync/model.py
@@ -1,0 +1,75 @@
+"""Pure data for sync-mirror: no I/O, no git, no network."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class SyncOpts:
+    """Resolved CLI intent for one run."""
+
+    target: str
+    base_ref: str = "origin/main"
+    pin: str = None
+    pins: dict = field(default_factory=dict)  # release -> sha, from --pins-from
+    accept_upstream: frozenset = frozenset()
+    retain: frozenset = frozenset()
+    retain_unverified: frozenset = frozenset()
+    worktree_path: str = None
+    apply: bool = False
+
+
+@dataclass(frozen=True)
+class Row:
+    """One key whose parsed value differs between the pre- and post-sync mirror."""
+
+    key: str
+    old: object
+    new: object
+    cls: str  # overridden | notation | representation | semantic
+    commits: tuple = ()
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Plan:  # pylint: disable=too-many-instance-attributes  # data record
+    """Everything a run would do, computed before anything is written."""
+
+    target_release: str
+    release_shas: dict
+    defaults_base_sha: str
+    prev_release: str
+    range_base_sha: str
+    mirror_writes: dict  # path -> desired bytes (the FULL layer)
+    mirror_deletes: tuple
+    compat_writes: dict  # path -> desired text
+    compat_deletes: tuple
+    unowned_compat: tuple  # existing 010 files lacking the generator marker
+    changed_writes: tuple  # paths whose bytes differ from what is on disk
+    created_paths: tuple  # changed_writes that do not exist yet
+    rows: tuple
+    added_keys: tuple
+    dropped_keys: dict  # key -> 010 destination path
+    added_files: tuple
+    deleted_files: tuple
+    # {010 path: {added/removed/updated: [keys]}}; absent for a file being created
+    compat_effects: dict = field(default_factory=dict)
+
+    @property
+    def blocked(self) -> tuple:
+        """Reasons --apply cannot proceed, independent of dispositions."""
+        return tuple(f"{p} lacks the generator marker" for p in self.unowned_compat)
+
+    @property
+    def has_changes(self) -> bool:
+        """True only if something on disk would actually change.
+
+        mirror_writes always holds the whole desired layer, unchanged files
+        included, so it can never be the signal here: deriving from it would make
+        "nothing to do" unreachable and report work pending on a correct tree.
+        """
+        return bool(self.changed_writes or self.mirror_deletes or self.compat_deletes)
+
+    @property
+    def semantic_keys(self) -> tuple:
+        """Keys needing a disposition, in row order."""
+        return tuple(r.key for r in self.rows if r.cls == "semantic")

--- a/src/osism_drift/mirror_sync/render.py
+++ b/src/osism_drift/mirror_sync/render.py
@@ -1,0 +1,140 @@
+"""Text and JSON renderers, and the exit status.
+
+Three independent facts sit behind the status -- whether anything would change,
+whether any semantic row lacks a disposition, and whether a write happened -- so
+each is its own JSON field. A single axis cannot express "work to do but nothing
+to review", which is the shape of an ordinary clean round.
+"""
+
+from .model import SyncOpts
+
+_CLASSES = ("semantic", "notation", "representation", "overridden")
+
+
+def _opts(plan, opts):
+    return opts or SyncOpts(target=plan.target_release)
+
+
+def _missing(plan, opts):
+    """Semantic keys with no disposition, in row order.
+
+    Only --accept-upstream counts. `retain` / `retain_unverified` exist on SyncOpts
+    for --apply, but the canonical-gate parser that gives them meaning is not
+    in this build: honouring them here would let a run report "all dispositioned"
+    without performing the checks those flags promise.
+    """
+    done = set(opts.accept_upstream)
+    return [k for k in plan.semantic_keys if k not in done]
+
+
+def json_payload(plan, opts=None, applied=None) -> dict:
+    """The machine-readable report. Stable, sorted, and free of wall-clock.
+
+    Carries target_release, release_shas and defaults_base_sha because
+    --pins-from reads exactly those three back to replay a run.
+    """
+    opts = _opts(plan, opts)
+    return {
+        "schema": 1,
+        "target_release": plan.target_release,
+        "release_shas": dict(sorted(plan.release_shas.items())),
+        "defaults_base_sha": plan.defaults_base_sha,
+        "prev_release": plan.prev_release,
+        "range_base_sha": plan.range_base_sha,
+        "has_changes": plan.has_changes,
+        "missing_dispositions": _missing(plan, opts),
+        "blocked": list(plan.blocked),
+        "applied": applied,
+        "counts": {
+            c: sum(1 for r in plan.rows if r.cls == c)
+            for c in _CLASSES
+            if any(r.cls == c for r in plan.rows)
+        },
+        "rows": [
+            {
+                "key": r.key,
+                "old": repr(r.old),
+                "new": repr(r.new),
+                "class": r.cls,
+                "commits": list(r.commits),
+                "note": r.note,
+            }
+            for r in sorted(plan.rows, key=lambda r: (r.cls, r.key))
+        ],
+        "changed_writes": sorted(plan.changed_writes),
+        "created_paths": sorted(plan.created_paths),
+        "deletes": sorted(plan.mirror_deletes) + sorted(plan.compat_deletes),
+        "added_files": sorted(plan.added_files),
+        "deleted_files": sorted(plan.deleted_files),
+        "added_keys": sorted(plan.added_keys),
+        "dropped_keys": dict(sorted(plan.dropped_keys.items())),
+    }
+
+
+def text(plan, opts=None) -> str:
+    """The human report."""
+    opts = _opts(plan, opts)
+    out = [
+        f"target {plan.target_release} @ "
+        f"{plan.release_shas.get(plan.target_release, '?')}",
+        f"defaults base {plan.defaults_base_sha}",
+        "",
+    ]
+    if not plan.rows:
+        # An empty section would read as "nothing was computed". Say which it is.
+        out.append("no value differences between the current and desired mirror")
+        out.append("")
+    for cls in _CLASSES:
+        rows = [r for r in plan.rows if r.cls == cls]
+        if not rows:
+            continue
+        out.append(f"{cls} ({len(rows)})")
+        for r in sorted(rows, key=lambda r: r.key):
+            out.append(f"  {r.key}: {r.old!r} -> {r.new!r}")
+            if r.note:
+                out.append(f"      {r.note}")
+            for line in r.commits:
+                out.append(f"      upstream: {line}")
+        out.append("")
+    if plan.added_files:
+        out.append(f"files added:   {', '.join(sorted(plan.added_files))}")
+    if plan.deleted_files:
+        out.append(f"files deleted: {', '.join(sorted(plan.deleted_files))}")
+    if plan.added_keys:
+        out.append(
+            f"keys added ({len(plan.added_keys)}): "
+            f"{', '.join(sorted(plan.added_keys))}"
+        )
+    if plan.dropped_keys:
+        out.append(f"keys dropped ({len(plan.dropped_keys)}):")
+        for key, dest in sorted(plan.dropped_keys.items()):
+            out.append(f"  {key} -> {dest}")
+    if plan.blocked:
+        out.append("")
+        out.append("--apply is blocked until these are resolved:")
+        out.extend(f"  {b}" for b in plan.blocked)
+        out.append(
+            "  (add the '# generated-by: sync-mirror' header line, or let sync-mirror "
+            "create the file)"
+        )
+    missing = _missing(plan, opts)
+    if missing:
+        out.append("")
+        # Only --accept-upstream exists in this build; naming the retention flags
+        # would point the operator at options argparse rejects.
+        out.append("needs a disposition (--accept-upstream):")
+        out.extend(f"  {k}" for k in missing)
+        out.append("  (retention dispositions arrive with --apply)")
+    return "\n".join(out) + "\n"
+
+
+def exit_code(plan, opts) -> int:
+    """0 clean | 1 changes, ready to apply | 2 operator action needed.
+
+    2 covers both an undispositioned semantic row and a blocker such as an
+    unowned 010 file: in either case --apply cannot proceed, so reporting 1
+    ("would apply cleanly") would be false.
+    """
+    if _missing(plan, opts) or plan.blocked:
+        return 2
+    return 1 if plan.has_changes else 0

--- a/src/osism_drift/mirror_sync/render.py
+++ b/src/osism_drift/mirror_sync/render.py
@@ -3,12 +3,77 @@
 Three independent facts sit behind the status -- whether anything would change,
 whether any semantic row lacks a disposition, and whether a write happened -- so
 each is its own JSON field. A single axis cannot express "work to do but nothing
-to review", which is the shape of an ordinary clean round.
+to review", which is the shape of an ordinary clean re-sync.
 """
+
+import shlex
+import textwrap
+from pathlib import Path
 
 from .model import SyncOpts
 
 _CLASSES = ("semantic", "notation", "representation", "overridden")
+
+# One line per class, from what classify() actually tests. A bare "semantic (16)"
+# does not tell a first-time reader whether those 16 are a problem.
+_SUMMARY = {
+    "semantic": "meaning changed and no rule explains it; blocks --apply",
+    "notation": "identical Jinja once whitespace beside {{ }} / {% %} is collapsed",
+    "representation": "bool spelling changed, truth value did not ('no' -> False)",
+    "overridden": "an unconditional OSISM layer already supplies the key",
+}
+
+_EXIT_MEANING = {
+    0: "nothing to do; the mirror already matches",
+    1: "changes ready to apply; re-run with --apply",
+    2: "operator action needed; the plan was not applied",
+    3: "refused; the plan was not applied",
+}
+
+# Longer than this, or containing a newline, and the terminal shows shape only.
+_INLINE_MAX = 60
+
+# Names shown per group before the list is truncated to a count.
+_NAME_CAP = 12
+
+
+def _inlinable(value) -> bool:
+    if isinstance(value, str) and "\n" in value:
+        return False
+    return len(repr(value)) <= _INLINE_MAX
+
+
+def _shape(value) -> str:
+    """A value too big to print, described well enough to recognise in the report."""
+    if isinstance(value, str):
+        lead = "multi-line " if "\n" in value else ""
+        return f"{lead}str, {len(value)} chars"
+    if isinstance(value, (list, tuple)):
+        return f"{type(value).__name__}, {_plural(len(value), 'item')}"
+    if isinstance(value, dict):
+        return f"dict, {_plural(len(value), 'key')}"
+    return type(value).__name__
+
+
+def _plural(n, noun) -> str:
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
+
+
+def _wrap_names(names, indent="    ", cap=_NAME_CAP) -> list:
+    """Wrapped name list, truncated past `cap`.
+
+    101 key names is 30 lines of terminal for one repeated finding. The names are
+    all in the detail file, so the terminal owes the reader a sample and a count,
+    not the set.
+    """
+    names = sorted(names)
+    shown, rest = names[:cap], len(names) - cap
+    text = ", ".join(shown)
+    if rest > 0:
+        text += f", ... and {rest} more (see report)"
+    return textwrap.wrap(
+        text, width=76, initial_indent=indent, subsequent_indent=indent
+    )
 
 
 def _opts(plan, opts):
@@ -16,18 +81,106 @@ def _opts(plan, opts):
 
 
 def _missing(plan, opts):
-    """Semantic keys with no disposition, in row order.
+    """Semantic keys carrying no disposition flag at all.
 
-    Only --accept-upstream counts. `retain` / `retain_unverified` exist on SyncOpts
-    for --apply, but the canonical-gate parser that gives them meaning is not
-    in this build: honouring them here would let a run report "all dispositioned"
-    without performing the checks those flags promise.
+    Validation is not done here: gate.validate_dispositions() raises on a bad
+    disposition, so by the time a report renders, every flag present is either
+    sound or the run has already exited 3. That keeps exit_code's signature
+    unchanged from the report-only build.
     """
-    done = set(opts.accept_upstream)
-    return [k for k in plan.semantic_keys if k not in done]
+    from . import gate
+
+    return gate.missing_dispositions(plan, opts)
 
 
-def json_payload(plan, opts=None, applied=None) -> dict:
+def acceptance_command(worktree_path, base_dirs, target=None, newest=None) -> str:
+    """The check-drift invocation that measures the synced tree.
+
+    Prepends the worktree's parent to the run's own base_dirs. Three things go
+    wrong otherwise:
+
+    - order: source._local_repo_dir() takes the first --base-dir containing a
+      directory named after the repo, so with the operator's checkout ahead of the
+      worktree the detector reads the unsynced tree and reports a pass on nothing;
+    - completeness: the run's other roots are needed too. Dropping the OpenStack
+      root loses kolla-ansible and the command cannot run at all;
+    - resolution policy: passing ANY --base-dir puts check-drift in local mode
+      (source._resolve returns remote only when base_dirs is empty), so a repo
+      absent from every root becomes a hard SourceError rather than a remote read.
+      The worktree parent holds only `defaults`, and a run with no --base-dir was
+      reading everything remotely, which this command would otherwise silently
+      convert to local-only. Hence --remote-fallback, unconditionally; it governs
+      repo resolution alone, so it costs nothing when every repo is local.
+
+    Every path is shell-quoted: this is copy-pasted, and an unquoted path with a
+    space in it silently means something else.
+    """
+    parent = str(Path(worktree_path).parent)
+    dirs = [parent] + [d for d in base_dirs if d != parent]
+    lines = "".join(f"    --base-dir {shlex.quote(d)} \\\n" for d in dirs)
+    cmd = (
+        "PYTHONPATH=src python3 src/check-drift.py --group all \\\n"
+        + lines
+        + "    --remote-fallback"
+    )
+    if target and newest and target != newest:
+        # check-drift derives its own range by globbing latest/openstack-*.yml and
+        # anchors the mirror on the newest of those, with no CLI flag to narrow it.
+        # So with a newer release declared, this command measures THAT re-sync and
+        # its count says nothing about the sync just applied. Say so rather than
+        # letting a large number read as a failure of this run.
+        cmd += (
+            f"\n\n# NOTE: the newest supported release is {newest}, not the "
+            f"{target} just synced.\n"
+            "# check-drift derives its range from latest/openstack-*.yml and has no\n"
+            "# flag to narrow it, so the command above measures the "
+            f"{newest} re-sync and\n"
+            f"# its count is not a verdict on this sync. To gate on {target}, set\n"
+            f'#   releases: [..., "{target}"]\n'
+            "# in src/drift-config.yml (or a copy passed with --config) first."
+        )
+    return cmd
+
+
+def commit_summary(plan, opts=None, notes=None) -> str:
+    """Provenance for the commit that carries an apply, ready to paste.
+
+    The generated 010 headers already record every pin, so the tree is not
+    missing that. What nothing records is which disposition each semantic key
+    got: accepting upstream leaves no trace at all, because the value simply
+    ends up matching upstream. That belongs in the commit message, and retyping
+    fifteen key names by hand is where it stops happening.
+
+    Wrapped at 72 columns, which is what a commit body wants.
+    """
+    opts = _opts(plan, opts)
+    out = [
+        f"Generated by sync-mirror for {plan.target_release}.",
+        "",
+        "Upstream pins (openstack/kolla-ansible ansible/group_vars/all):",
+    ]
+    out += [f"  {r}: {plan.release_shas[r]}" for r in sorted(plan.release_shas)]
+    out.append(f"osism/defaults base: {plan.defaults_base_sha}")
+    groups = [
+        ("accepted upstream", sorted(opts.accept_upstream)),
+        ("retained, gate verified", sorted(opts.retain)),
+        ("retained, gate NOT verified", sorted(opts.retain_unverified)),
+    ]
+    present = [(label, keys) for label, keys in groups if keys]
+    if present:
+        out += ["", "Dispositions:"]
+        for label, keys in present:
+            out.append(f"  {label} ({len(keys)}):")
+            out += textwrap.wrap(
+                ", ".join(keys),
+                width=72,
+                initial_indent="    ",
+                subsequent_indent="    ",
+            )
+    return "\n".join(out) + "\n"
+
+
+def json_payload(plan, opts=None, applied=None, notes=None) -> dict:
     """The machine-readable report. Stable, sorted, and free of wall-clock.
 
     Carries target_release, release_shas and defaults_base_sha because
@@ -44,6 +197,7 @@ def json_payload(plan, opts=None, applied=None) -> dict:
         "has_changes": plan.has_changes,
         "missing_dispositions": _missing(plan, opts),
         "blocked": list(plan.blocked),
+        "dispositions": dict(sorted((notes or {}).items())),
         "applied": applied,
         "counts": {
             c: sum(1 for r in plan.rows if r.cls == c)
@@ -71,44 +225,29 @@ def json_payload(plan, opts=None, applied=None) -> dict:
     }
 
 
-def text(plan, opts=None) -> str:
-    """The human report."""
+def text(plan, opts=None, notes=None, code=None, report_path=None, applied=None) -> str:
+    """The human report: what to decide, not what changed.
+
+    Every full value lives in the detail file instead. A re-wrapped Jinja
+    expression repr()s to a single 1400-char line, and printing a hundred of them
+    ahead of the actionable tail buries the only part an operator acts on.
+    """
     opts = _opts(plan, opts)
     out = [
-        f"target {plan.target_release} @ "
+        f"target        {plan.target_release} @ "
         f"{plan.release_shas.get(plan.target_release, '?')}",
-        f"defaults base {plan.defaults_base_sha}",
+        f"defaults base {opts.base_ref} @ {plan.defaults_base_sha}",
         "",
     ]
     if not plan.rows:
         # An empty section would read as "nothing was computed". Say which it is.
         out.append("no value differences between the current and desired mirror")
         out.append("")
-    for cls in _CLASSES:
-        rows = [r for r in plan.rows if r.cls == cls]
-        if not rows:
-            continue
-        out.append(f"{cls} ({len(rows)})")
-        for r in sorted(rows, key=lambda r: r.key):
-            out.append(f"  {r.key}: {r.old!r} -> {r.new!r}")
-            if r.note:
-                out.append(f"      {r.note}")
-            for line in r.commits:
-                out.append(f"      upstream: {line}")
-        out.append("")
-    if plan.added_files:
-        out.append(f"files added:   {', '.join(sorted(plan.added_files))}")
-    if plan.deleted_files:
-        out.append(f"files deleted: {', '.join(sorted(plan.deleted_files))}")
-    if plan.added_keys:
-        out.append(
-            f"keys added ({len(plan.added_keys)}): "
-            f"{', '.join(sorted(plan.added_keys))}"
-        )
-    if plan.dropped_keys:
-        out.append(f"keys dropped ({len(plan.dropped_keys)}):")
-        for key, dest in sorted(plan.dropped_keys.items()):
-            out.append(f"  {key} -> {dest}")
+    else:
+        out.extend(_summary(plan))
+        out.extend(_semantic_section(plan))
+        out.extend(_grouped_sections(plan))
+    out.extend(_file_and_key_moves(plan))
     if plan.blocked:
         out.append("")
         out.append("--apply is blocked until these are resolved:")
@@ -117,15 +256,164 @@ def text(plan, opts=None) -> str:
             "  (add the '# generated-by: sync-mirror' header line, or let sync-mirror "
             "create the file)"
         )
+    if notes:
+        out.append("")
+        out.append("dispositioned:")
+        for key in sorted(notes):
+            out.append(f"  {key}: {notes[key]}")
     missing = _missing(plan, opts)
     if missing:
         out.append("")
-        # Only --accept-upstream exists in this build; naming the retention flags
-        # would point the operator at options argparse rejects.
-        out.append("needs a disposition (--accept-upstream):")
+        out.append(
+            "needs a disposition (--accept-upstream / --retain / "
+            "--retain-unverified):"
+        )
         out.extend(f"  {k}" for k in missing)
-        out.append("  (retention dispositions arrive with --apply)")
+    if report_path:
+        out.append("")
+        out.append(f"full values for every key: {report_path}")
+    if code is not None:
+        out.append("")
+        # Exit 0 means two different things: a run that had nothing to do, and a
+        # run that applied everything. Reporting "the mirror already matches"
+        # after writing 47 files is worse than saying nothing.
+        meaning = (
+            "the plan was applied to the worktree"
+            if applied
+            else _EXIT_MEANING.get(code, "unknown")
+        )
+        out.append(f"exit {code}: {meaning}")
     return "\n".join(out) + "\n"
+
+
+def _summary(plan) -> list:
+    """The counts table. Each class says what it means, so a bare number does not
+    send the reader to the source to find out whether it needs them."""
+    counts = {c: sum(1 for r in plan.rows if r.cls == c) for c in _CLASSES}
+    present = [c for c in _CLASSES if counts[c]]
+    sem = counts["semantic"]
+    lead = f"{len(plan.rows)} mirror values changed. "
+    lead += (
+        f"{sem} need a decision from you; the rest are carried through."
+        if sem
+        else "None need a decision."
+    )
+    width = max(len(c) for c in present)
+    rows = [f"  {c:<{width}} {counts[c]:>4}  {_SUMMARY[c]}" for c in present]
+    return [lead, ""] + rows + [""]
+
+
+def _semantic_section(plan) -> list:
+    """Semantic rows in full-ish: the only class the operator has to read.
+
+    A value is inlined only when it is short and single-line. Anything else is
+    described by shape and left to the detail file -- the terminal cannot render
+    a 500-char re-wrap in a form anyone would read.
+    """
+    rows = [r for r in plan.rows if r.cls == "semantic"]
+    if not rows:
+        return []
+    out = [
+        f"semantic ({len(rows)}) - each needs --accept-upstream / --retain / "
+        "--retain-unverified"
+    ]
+    for r in sorted(rows, key=lambda r: r.key):
+        if _inlinable(r.old) and _inlinable(r.new):
+            out.append(f"  {r.key}: {r.old!r} -> {r.new!r}")
+        else:
+            out.append(f"  {r.key}: {_shape(r.old)} -> {_shape(r.new)} (see report)")
+        for line in r.commits:
+            out.append(f"      upstream: {line}")
+    return out + [""]
+
+
+def _grouped_sections(plan) -> list:
+    """The three non-gating classes, grouped by note.
+
+    classify() emits a fixed note per class (overridden varies only by supplying
+    layer), so a section is a handful of groups however many keys it holds. The
+    old shape repeated one constant sentence 101 times.
+    """
+    out = []
+    for cls in _CLASSES:
+        if cls == "semantic":
+            continue
+        rows = [r for r in plan.rows if r.cls == cls]
+        if not rows:
+            continue
+        out.append(f"{cls} ({len(rows)}) - carried through, no decision needed")
+        groups = {}
+        for r in rows:
+            groups.setdefault(r.note, []).append(r.key)
+        for note, keys in sorted(groups.items()):
+            out.extend(
+                textwrap.wrap(
+                    f"{note or 'no note'} ({len(keys)}):",
+                    width=78,
+                    initial_indent="  ",
+                    subsequent_indent="  ",
+                )
+            )
+            out.extend(_wrap_names(keys))
+        out.append("")
+    return out
+
+
+def _file_and_key_moves(plan) -> list:
+    """File-level effects and the added/dropped key counts.
+
+    Dropped keys are summarised per destination: the names are in the detail
+    file, and 75 of them ahead of the blocked list is what pushed the actionable
+    tail off the screen.
+    """
+    out = []
+    if plan.added_files:
+        out.append(f"files added ({len(plan.added_files)}):")
+        out.extend(_wrap_names(plan.added_files))
+    if plan.deleted_files:
+        out.append(f"files deleted ({len(plan.deleted_files)}):")
+        out.extend(_wrap_names(plan.deleted_files))
+    if plan.added_keys:
+        out.append(f"keys added ({len(plan.added_keys)}) - listed in the report")
+    if plan.dropped_keys:
+        dests = {}
+        for key, dest in plan.dropped_keys.items():
+            dests.setdefault(dest, []).append(key)
+        out.append(
+            f"keys routed into back-compat layers ({len(plan.dropped_keys)} in the "
+            "desired tree, not all of them new):"
+        )
+        for dest, keys in sorted(dests.items()):
+            out.append(f"  {dest}: {_plural(len(keys), 'key')} ({_status(plan, dest)})")
+    return out
+
+
+def _status(plan, path) -> str:
+    """What this run actually does to one back-compat layer.
+
+    "rewritten" is true but reads as data loss, and a 010 file is rewritten on
+    every run regardless: its header carries the pinned commit of each release in
+    range, so the bytes move even when no key does. Report the key-level effect
+    and name the header explicitly when that is the only change.
+    """
+    if path in plan.created_paths:
+        return "new file"
+    eff = plan.compat_effects.get(path)
+    if eff is None:
+        return "unchanged" if path not in plan.changed_writes else "updated"
+    parts = []
+    if eff["added"]:
+        parts.append(f"+{_plural(len(eff['added']), 'key')}")
+    if eff["removed"]:
+        parts.append(f"-{_plural(len(eff['removed']), 'key')}")
+    if eff["updated"]:
+        parts.append(f"{_plural(len(eff['updated']), 'value')} updated")
+    if parts:
+        return ", ".join(parts)
+    if path in plan.changed_writes:
+        # Same keys, same values: only the pinned-commit header moved.
+        return "same keys and values; only the pin header is refreshed"
+    return "unchanged"
 
 
 def exit_code(plan, opts) -> int:

--- a/src/osism_drift/mirror_sync/worktree.py
+++ b/src/osism_drift/mirror_sync/worktree.py
@@ -1,0 +1,123 @@
+"""Worktree lifecycle for sync-mirror.
+
+Both report and apply read a worktree created from --base-ref. Report removes it
+on exit; apply keeps it as the artifact to review. Sharing the tree is what makes
+report and apply the same plan, and it means the operator's uncommitted work is
+never consulted -- which the report states, so nobody expects it to be.
+
+Writing into a throwaway tree also removes a whole category of hazard the earlier
+in-place design needed guards for: no dirty-tree check, no --allow-dirty escape,
+no recovery command that has to distinguish tracked from created files.
+"""
+
+import re
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+class WorktreeError(Exception):
+    """Base for every worktree failure, so the CLI can map them all to exit 3."""
+
+
+class WorktreeExists(WorktreeError):
+    """The target path is already present; refuse rather than guess."""
+
+
+class CreateFailed(WorktreeError):
+    """The worktree could not be created, or its HEAD did not verify."""
+
+
+class CleanupFailed(WorktreeError):
+    """The worktree could not be removed; the next run would refuse on its path."""
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, check=False
+    )
+
+
+def default_path(defaults_dir, target) -> Path:
+    """<defaults-repo>.worktrees/sync-<target>/defaults
+
+    The leaf must be named `defaults`: source._local_repo_dir() resolves a repo as
+    <base-dir>/<repo-name>, so check-drift can only address the synced tree if the
+    directory is called that. The nesting keeps the workspace's .worktrees layout.
+    """
+    d = Path(defaults_dir).resolve()
+    return d.parent / f"{d.name}.worktrees" / f"sync-{target}" / "defaults"
+
+
+def create(defaults_dir, path, base_ref) -> str:
+    """Add a detached worktree at `path` from `base_ref`; return its commit."""
+    path = Path(path)
+    if path.exists():
+        raise WorktreeExists(
+            f"{path} already exists; remove it "
+            f"(git -C {defaults_dir} worktree remove {path} --force) "
+            "or pass --worktree-path"
+        )
+    r = _git(defaults_dir, "worktree", "add", str(path), "--detach", base_ref)
+    if r.returncode != 0:
+        raise CreateFailed(
+            f"git worktree add failed: {r.stderr.decode().strip() or r.returncode}"
+        )
+    head = _git(path, "rev-parse", "HEAD")
+    sha = head.stdout.decode().strip()
+    if head.returncode != 0 or not _SHA40.match(sha):
+        # A worktree we cannot identify is useless and must not be left behind:
+        # the next run would refuse on its path.
+        err = CreateFailed(
+            f"worktree at {path} created but HEAD did not resolve to a commit"
+        )
+        if not remove(defaults_dir, path):
+            raise CleanupFailed(
+                f"{err}; and it could not be removed -- run "
+                f"'git -C {defaults_dir} worktree remove {path} --force'"
+            ) from err
+        raise err
+    return sha
+
+
+def remove(defaults_dir, path) -> bool:
+    """Remove the worktree. True on success; the caller decides how loud to be."""
+    return (
+        _git(defaults_dir, "worktree", "remove", str(path), "--force").returncode == 0
+    )
+
+
+@contextmanager
+def session(defaults_dir, path, base_ref, keep=False):
+    """Yield (path, base_sha); remove the worktree on exit unless `keep`.
+
+    Removal happens on the exception path too, so a refused run leaves nothing
+    behind. Report mode always removes; apply keeps it once a write has started.
+
+    A failed cleanup is not swallowed: it leaves the default path occupied, so the
+    next run refuses and the operator sees a confusing "already exists" instead of
+    the real cause. On the happy path that raises CleanupFailed; on an exception
+    path the original error is chained onto it, so the first diagnostic survives.
+    """
+    path = Path(path)
+    # Evaluated at EXIT, not entry: an apply refused for a missing disposition or
+    # a failed gate must not keep the tree, and only the caller knows -- at the
+    # end -- whether a write actually began.
+    keep_now = keep if callable(keep) else (lambda: keep)
+    sha = create(defaults_dir, path, base_ref)
+    try:
+        yield path, sha
+    except BaseException as exc:
+        if not keep_now() and not remove(defaults_dir, path):
+            raise CleanupFailed(
+                f"{path} could not be removed -- run "
+                f"'git -C {defaults_dir} worktree remove {path} --force'"
+            ) from exc
+        raise
+    if not keep_now() and not remove(defaults_dir, path):
+        raise CleanupFailed(
+            f"report finished but {path} could not be removed -- run "
+            f"'git -C {defaults_dir} worktree remove {path} --force'"
+        )

--- a/src/osism_drift/mirror_sync/write.py
+++ b/src/osism_drift/mirror_sync/write.py
@@ -1,0 +1,97 @@
+"""Apply a Plan to the worktree.
+
+Deliberately dull: every decision was made while computing the Plan. The writer
+refuses to act on a plan that says it is blocked, confines paths, signals when it
+starts mutating, and writes in a defined order.
+"""
+
+from pathlib import Path
+
+_ALL = "all"
+
+
+class WriteFailed(Exception):
+    """Refused before writing, or failed part-way through."""
+
+
+def _resolve(tree, rel):
+    """Confine `rel` beneath <tree>/all before it becomes a filesystem path.
+
+    Checked lexically, then component by component -- never by resolving the
+    candidate and comparing it to a resolved root. Deriving the root from the same
+    path being checked is not a confinement check: with `all` a symlink to an
+    external directory, both sides resolve into that directory and every write
+    lands outside the worktree while the comparison passes. Measured before the
+    fix: `_resolve(tree, "all/001-nova.yml")` returned a path under /tmp/outside
+    and was accepted.
+
+    So: reject an absolute path or any `..` component up front, require the first
+    component to be `all`, and refuse if any component along the way is a symlink.
+    The last one also stops the writer mutating a link's target instead of the
+    planned path.
+    """
+    rel_path = Path(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        raise WriteFailed(f"{rel} is not a plain relative path beneath {_ALL}/")
+    if rel_path.parts[:1] != (_ALL,):
+        raise WriteFailed(f"{rel} is not beneath {_ALL}/")
+
+    root = Path(tree)
+    cur = root
+    for part in rel_path.parts:
+        cur = cur / part
+        if cur.is_symlink():
+            raise WriteFailed(
+                f"{rel}: {cur} is a symlink; refusing to write or delete through it"
+            )
+    return cur
+
+
+def apply_plan(plan, tree, on_first_write=None) -> dict:
+    """Write the changed paths and apply the deletes. Returns what it did.
+
+    `on_first_write` is called once, after preflight and immediately before the
+    first mutation. The caller uses it to decide the worktree's fate: a failure
+    before it means nothing was touched and the tree can be removed, while a
+    failure after it leaves partial state that must be preserved for inspection.
+    Signalling only on a successful return would delete the evidence of a
+    part-way failure -- exactly the state worth keeping.
+    """
+    if plan.blocked:
+        raise WriteFailed("plan is blocked: " + "; ".join(plan.blocked))
+
+    desired = dict(plan.mirror_writes)
+    desired.update(plan.compat_writes)
+
+    # Preflight: resolve every path and confirm every content before touching any
+    # of them, so a bad path cannot leave a half-applied tree.
+    todo = []
+    for rel in plan.changed_writes:
+        if rel not in desired:
+            raise WriteFailed(f"{rel} is in changed_writes but has no desired content")
+        todo.append((rel, _resolve(tree, rel), desired[rel]))
+    dels = [
+        (rel, _resolve(tree, rel))
+        for rel in tuple(plan.mirror_deletes) + tuple(plan.compat_deletes)
+    ]
+
+    if on_first_write is not None:
+        on_first_write()
+
+    written = []
+    for rel, path, content in todo:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+        written.append(rel)
+
+    # Deletes last: an interrupted run then leaves a tree with too much rather
+    # than too little, which is the easier state to reason about.
+    deleted = []
+    for rel, path in dels:
+        if path.exists():
+            path.unlink()
+            deleted.append(rel)
+    return {"written": written, "deleted": deleted}

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -5,6 +5,7 @@ A set `branch` *pins* the repo: it is always read remotely at that ref, so the
 result is deterministic regardless of any local checkout's current branch.
 """
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -398,6 +399,174 @@ def release_to_ref(repo: str, release: str, config) -> str:
         f"no upstream ref for {repo} release {release}: tried {tried} "
         f"(set release_refs to override)"
     )
+
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _checked_sha(repo: str, ref: str, sha: str) -> str:
+    """Enforce resolve_commit's documented contract at its own boundary.
+
+    Callers pin refs from this value, so an abbreviated or malformed id must not
+    escape just because the current call sites happen to re-validate later.
+    """
+    if not _SHA40.match(sha):
+        raise SourceError(
+            f"{repo}: resolving {ref!r} gave {sha!r}, not a 40-hex commit"
+        )
+    return sha
+
+
+def local_checkout(repo: str, config):
+    """The local git dir backing `repo`, or None when this run reads remotely.
+
+    Lets callers branch on locality (attribution needs `git log`) without reaching
+    into _resolve from another module.
+    """
+    where, d = _resolve(repo, config)
+    return d if (where == "local" and _is_pinned(repo, config)) else None
+
+
+def _resolve_upstream_ref(repo, d, ref):
+    """Resolve an upstream release ref, preferring remote-tracking over local.
+
+    _resolve_local_ref() tries the bare ref first, which is right for a consumer
+    repo read as a working tree but wrong for a pinned upstream read at a release
+    ref: a stale local branch of the same name then silently wins. Observed in a
+    real checkout -- refs/heads/stable/2025.2 sat five commits behind
+    refs/remotes/origin/stable/2025.2, and sync-mirror proposed reverting an
+    upstream fix that had landed in between.
+
+    Remotes are tried in name order for determinism. A local head is used only
+    when no remote carries the ref, and a disagreement is announced rather than
+    resolved quietly.
+    """
+    # Enumerate the refs that exist rather than the configured remotes: a clone can
+    # carry refs/remotes/<r>/<ref> without <r> being listed by `git remote`.
+    found = (
+        _git(d, "for-each-ref", "--format=%(refname)", f"refs/remotes/*/{ref}")
+        .stdout.decode()
+        .split()
+    )
+    if found:
+        cand = sorted(found)[0]
+        local = _git(d, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+        if local.returncode == 0:
+            lo = local.stdout.decode().strip()
+            hi = _git(d, "rev-parse", f"{cand}^{{commit}}").stdout.decode().strip()
+            if lo != hi:
+                _note(
+                    "stale local ref",
+                    repo,
+                    ref,
+                    f"local {lo[:12]} != {cand} {hi[:12]}; using {cand}",
+                )
+        return cand
+    if _git(d, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}").returncode == 0:
+        return ref
+    raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+
+
+def resolve_commit(repo: str, ref: str, config) -> str:
+    """Peel `ref` to a 40-hex commit id in the upstream repo.
+
+    release_to_ref() yields a ref NAME (stable/<r>, unmaintained/<r>, <r>-eol,
+    <r>-eom); a verbatim mirror has to record the commit, because those branches
+    take backports and a name is not a reproducible snapshot. Local reads use the
+    clone's own resolution (which also tries <remote>/<ref>); remote reads take
+    .sha from the same commits endpoint ref_exists() already calls.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        cand = _resolve_upstream_ref(repo, d, ref)
+        out = _git(d, "rev-parse", "--verify", "--quiet", f"{cand}^{{commit}}")
+        if out.returncode != 0:
+            raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+        return _checked_sha(repo, ref, out.stdout.decode().strip())
+    owner = _owner(repo, config)
+    url = f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/commits/{ref}"
+    _note("commit?", repo, ref)
+    r = _get("resolving commit", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+    sha = (r.json() or {}).get("sha")
+    if not sha:
+        raise SourceError(f"commits API returned no sha for {repo} {ref!r}")
+    return _checked_sha(repo, ref, sha)
+
+
+def _require_objects(repo, d, *shas):
+    for sha in shas:
+        if _git(d, "cat-file", "-e", f"{sha}^{{commit}}").returncode != 0:
+            raise SourceError(
+                f"{repo}: {sha[:12]} not present locally (shallow clone?); "
+                "cannot compare history"
+            )
+
+
+def is_ancestor(repo: str, ancestor: str, descendant: str, config) -> bool:
+    """True if `ancestor` is reachable from `descendant`.
+
+    `git merge-base --is-ancestor` exits 0 for yes, 1 for a valid "no", and
+    anything else (128 for an unknown commit) for an operational failure. Mapping
+    every non-zero to False would report "not an ancestor" for a broken comparison
+    and let a wrong pin through, so only 0 and 1 are treated as answers.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        _require_objects(repo, d, ancestor, descendant)
+        rc = _git(d, "merge-base", "--is-ancestor", ancestor, descendant).returncode
+        if rc == 0:
+            return True
+        if rc == 1:
+            return False
+        raise SourceError(
+            f"{repo}: cannot compare {ancestor[:12]}..{descendant[:12]} "
+            f"(git exit {rc})"
+        )
+    owner = _owner(repo, config)
+    url = (
+        f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}"
+        f"/compare/{ancestor}...{descendant}"
+    )
+    _note("compare", repo, f"{ancestor[:12]}..{descendant[:12]}")
+    r = _get("comparing refs", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"{repo}: cannot compare {ancestor[:12]}..{descendant[:12]}")
+    return (r.json() or {}).get("status") in ("identical", "ahead")
+
+
+def merge_base(repo: str, a: str, b: str, config):
+    """Best common ancestor of `a` and `b`, or None if they share no history.
+
+    Public because sync-mirror needs it in both modes: locally `git merge-base`,
+    remotely merge_base_commit.sha from the same compare endpoint is_ancestor uses.
+    Only exit 1 means "no merge base"; anything else is a failure, because a caller
+    that reads a failure as "none" would silently skip a bound it depends on.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        _require_objects(repo, d, a, b)
+        r = _git(d, "merge-base", a, b)
+        if r.returncode == 0:
+            return r.stdout.decode().strip()
+        if r.returncode == 1:
+            return None
+        raise SourceError(
+            f"{repo}: merge-base {a[:12]}..{b[:12]} failed (git exit {r.returncode})"
+        )
+    owner = _owner(repo, config)
+    url = (
+        f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/compare/{a}...{b}"
+    )
+    _note("merge-base", repo, f"{a[:12]}..{b[:12]}")
+    r = _get("finding merge base", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"{repo}: cannot compare {a[:12]}..{b[:12]}")
+    sha = ((r.json() or {}).get("merge_base_commit") or {}).get("sha")
+    if sha is not None and not _SHA40.match(sha):
+        raise SourceError(f"{repo}: compare returned a bad merge base {sha!r}")
+    return sha
 
 
 def read_at_ref(

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -5,6 +5,7 @@ A set `branch` *pins* the repo: it is always read remotely at that ref, so the
 result is deterministic regardless of any local checkout's current branch.
 """
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -430,6 +431,174 @@ def release_to_ref(repo: str, release: str, config) -> str:
         f"no upstream ref for {repo} release {release}: tried {tried} "
         f"(set release_refs to override)"
     )
+
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _checked_sha(repo: str, ref: str, sha: str) -> str:
+    """Enforce resolve_commit's documented contract at its own boundary.
+
+    Callers pin refs from this value, so an abbreviated or malformed id must not
+    escape just because the current call sites happen to re-validate later.
+    """
+    if not _SHA40.match(sha):
+        raise SourceError(
+            f"{repo}: resolving {ref!r} gave {sha!r}, not a 40-hex commit"
+        )
+    return sha
+
+
+def local_checkout(repo: str, config):
+    """The local git dir backing `repo`, or None when this run reads remotely.
+
+    Lets callers branch on locality (attribution needs `git log`) without reaching
+    into _resolve from another module.
+    """
+    where, d = _resolve(repo, config)
+    return d if (where == "local" and _is_pinned(repo, config)) else None
+
+
+def _resolve_upstream_ref(repo, d, ref):
+    """Resolve an upstream release ref, preferring remote-tracking over local.
+
+    _resolve_local_ref() tries the bare ref first, which is right for a consumer
+    repo read as a working tree but wrong for a pinned upstream read at a release
+    ref: a stale local branch of the same name then silently wins. Observed in a
+    real checkout -- refs/heads/stable/2025.2 sat five commits behind
+    refs/remotes/origin/stable/2025.2, and sync-mirror proposed reverting an
+    upstream fix that had landed in between.
+
+    Remotes are tried in name order for determinism. A local head is used only
+    when no remote carries the ref, and a disagreement is announced rather than
+    resolved quietly.
+    """
+    # Enumerate the refs that exist rather than the configured remotes: a clone can
+    # carry refs/remotes/<r>/<ref> without <r> being listed by `git remote`.
+    found = (
+        _git(d, "for-each-ref", "--format=%(refname)", f"refs/remotes/*/{ref}")
+        .stdout.decode()
+        .split()
+    )
+    if found:
+        cand = sorted(found)[0]
+        local = _git(d, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+        if local.returncode == 0:
+            lo = local.stdout.decode().strip()
+            hi = _git(d, "rev-parse", f"{cand}^{{commit}}").stdout.decode().strip()
+            if lo != hi:
+                _note(
+                    "stale local ref",
+                    repo,
+                    ref,
+                    f"local {lo[:12]} != {cand} {hi[:12]}; using {cand}",
+                )
+        return cand
+    if _git(d, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}").returncode == 0:
+        return ref
+    raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+
+
+def resolve_commit(repo: str, ref: str, config) -> str:
+    """Peel `ref` to a 40-hex commit id in the upstream repo.
+
+    release_to_ref() yields a ref NAME (stable/<r>, unmaintained/<r>, <r>-eol,
+    <r>-eom); a verbatim mirror has to record the commit, because those branches
+    take backports and a name is not a reproducible snapshot. Local reads use the
+    clone's own resolution (which also tries <remote>/<ref>); remote reads take
+    .sha from the same commits endpoint ref_exists() already calls.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        cand = _resolve_upstream_ref(repo, d, ref)
+        out = _git(d, "rev-parse", "--verify", "--quiet", f"{cand}^{{commit}}")
+        if out.returncode != 0:
+            raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+        return _checked_sha(repo, ref, out.stdout.decode().strip())
+    owner = _owner(repo, config)
+    url = f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/commits/{ref}"
+    _note("commit?", repo, ref)
+    r = _get("resolving commit", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"cannot resolve {ref!r} to a commit in {repo}")
+    sha = (r.json() or {}).get("sha")
+    if not sha:
+        raise SourceError(f"commits API returned no sha for {repo} {ref!r}")
+    return _checked_sha(repo, ref, sha)
+
+
+def _require_objects(repo, d, *shas):
+    for sha in shas:
+        if _git(d, "cat-file", "-e", f"{sha}^{{commit}}").returncode != 0:
+            raise SourceError(
+                f"{repo}: {sha[:12]} not present locally (shallow clone?); "
+                "cannot compare history"
+            )
+
+
+def is_ancestor(repo: str, ancestor: str, descendant: str, config) -> bool:
+    """True if `ancestor` is reachable from `descendant`.
+
+    `git merge-base --is-ancestor` exits 0 for yes, 1 for a valid "no", and
+    anything else (128 for an unknown commit) for an operational failure. Mapping
+    every non-zero to False would report "not an ancestor" for a broken comparison
+    and let a wrong pin through, so only 0 and 1 are treated as answers.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        _require_objects(repo, d, ancestor, descendant)
+        rc = _git(d, "merge-base", "--is-ancestor", ancestor, descendant).returncode
+        if rc == 0:
+            return True
+        if rc == 1:
+            return False
+        raise SourceError(
+            f"{repo}: cannot compare {ancestor[:12]}..{descendant[:12]} "
+            f"(git exit {rc})"
+        )
+    owner = _owner(repo, config)
+    url = (
+        f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}"
+        f"/compare/{ancestor}...{descendant}"
+    )
+    _note("compare", repo, f"{ancestor[:12]}..{descendant[:12]}")
+    r = _get("comparing refs", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"{repo}: cannot compare {ancestor[:12]}..{descendant[:12]}")
+    return (r.json() or {}).get("status") in ("identical", "ahead")
+
+
+def merge_base(repo: str, a: str, b: str, config):
+    """Best common ancestor of `a` and `b`, or None if they share no history.
+
+    Public because sync-mirror needs it in both modes: locally `git merge-base`,
+    remotely merge_base_commit.sha from the same compare endpoint is_ancestor uses.
+    Only exit 1 means "no merge base"; anything else is a failure, because a caller
+    that reads a failure as "none" would silently skip a bound it depends on.
+    """
+    d = local_checkout(repo, config)
+    if d is not None:
+        _require_objects(repo, d, a, b)
+        r = _git(d, "merge-base", a, b)
+        if r.returncode == 0:
+            return r.stdout.decode().strip()
+        if r.returncode == 1:
+            return None
+        raise SourceError(
+            f"{repo}: merge-base {a[:12]}..{b[:12]} failed (git exit {r.returncode})"
+        )
+    owner = _owner(repo, config)
+    url = (
+        f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/compare/{a}...{b}"
+    )
+    _note("merge-base", repo, f"{a[:12]}..{b[:12]}")
+    r = _get("finding merge base", url, json_api=True, ok=(404, 422))
+    if r.status_code in (404, 422):
+        raise SourceError(f"{repo}: cannot compare {a[:12]}..{b[:12]}")
+    sha = ((r.json() or {}).get("merge_base_commit") or {}).get("sha")
+    if sha is not None and not _SHA40.match(sha):
+        raise SourceError(f"{repo}: compare returned a bad merge base {sha!r}")
+    return sha
 
 
 def read_at_ref(

--- a/src/sync-mirror.py
+++ b/src/sync-mirror.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import shlex
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -11,7 +12,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from osism_drift import config as cfgmod  # noqa: E402
 from osism_drift import enablement, mirror_sync, source  # noqa: E402
-from osism_drift.mirror_sync import layers, effective, render, worktree  # noqa: E402
+from osism_drift.mirror_sync import (  # noqa: E402
+    classify,
+    commit as commit_mod,
+    detail,
+    effective,
+    gate,
+    layers,
+    render,
+    worktree,
+    write,
+)
 from osism_drift.mirror_sync.model import SyncOpts  # noqa: E402
 
 here = Path(__file__).resolve().parent
@@ -20,24 +31,98 @@ _DEFAULT_BASE_REF = "origin/main"
 
 def _parser():
     p = argparse.ArgumentParser(
-        description="Report the re-sync of osism/defaults' kolla mirror for a release."
+        description="Report the re-sync of osism/defaults' kolla mirror for a release.",
+        epilog=(
+            "exit codes:\n"
+            "  0  nothing to do; the mirror already matches\n"
+            "  1  changes ready to apply; re-run with --apply\n"
+            "  2  operator action needed (a semantic key without a disposition,\n"
+            "     or an existing 010 file this tool does not own)\n"
+            "  3  refused; nothing was written\n"
+            "\ntypical run:\n"
+            "  tox -e sync-mirror -- --target 2026.1 \\\n"
+            "      --defaults-dir ~/src/osism/defaults \\\n"
+            "      --base-dir ~/src/osism --base-dir ~/src/openstack\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument("--config", default=str(here / "drift-config.yml"))
+    p.add_argument(
+        "--config",
+        default=str(here / "drift-config.yml"),
+        help="drift config; supplies the release range and upstream branches",
+    )
     p.add_argument("--target", help="release to mirror; default newest supported")
     p.add_argument(
         "--defaults-dir", help="osism/defaults checkout (required in both modes)"
     )
-    p.add_argument("--base-dir", action="append", default=[], dest="base_dirs")
-    p.add_argument("--base-ref", default=_DEFAULT_BASE_REF)
+    p.add_argument(
+        "--base-dir",
+        action="append",
+        default=[],
+        dest="base_dirs",
+        metavar="DIR",
+        help="repeatable root holding checkouts; first match wins per repo",
+    )
+    p.add_argument(
+        "--base-ref",
+        default=_DEFAULT_BASE_REF,
+        help="ref in --defaults-dir the throwaway worktree is built from "
+        f"(default {_DEFAULT_BASE_REF}); point it at your own branch",
+    )
     p.add_argument("--pin", help="upstream commit for --target")
     p.add_argument("--pins-from", help="report.json to replay every pin from")
-    # --accept-upstream only. --retain / --retain-unverified arrive with --apply,
-    # which owns the canonical-gate parser that gives them meaning; accepting
-    # them here would let a run report "all dispositioned" without the checks.
-    p.add_argument("--accept-upstream", action="append", default=[])
-    p.add_argument("--worktree-path")
-    p.add_argument("--apply", action="store_true")
-    p.add_argument("--format", choices=("text", "json"), default="text")
+    p.add_argument(
+        "--accept-upstream",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="take the upstream value for KEY; repeatable",
+    )
+    p.add_argument(
+        "--retain",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="keep the OSISM value for KEY; verified against the 099 gate",
+    )
+    p.add_argument(
+        "--retain-unverified",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="keep the OSISM value for KEY when its gate exists but cannot "
+        "be parsed; use only after reading the gate yourself",
+    )
+    p.add_argument(
+        "--worktree-path",
+        metavar="PATH",
+        help="where to build the throwaway worktree (default: "
+        "<defaults>.worktrees/sync-<target>/defaults)",
+    )
+    p.add_argument(
+        "--report-file",
+        metavar="PATH",
+        help="full per-key values (default: ./sync-mirror-<target>.txt)",
+    )
+    p.add_argument(
+        "--apply", action="store_true", help="write the plan into the worktree"
+    )
+    p.add_argument(
+        "--commit",
+        action="store_true",
+        help="with --apply: branch the worktree and commit what was written",
+    )
+    p.add_argument(
+        "--commit-branch",
+        metavar="NAME",
+        help="branch --commit creates (default: sync-mirror/<target>)",
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="text for people, json for tooling and --pins-from",
+    )
     return p
 
 
@@ -47,12 +132,23 @@ def main(argv=None):
     if not args.defaults_dir:
         print("--defaults-dir is required", file=sys.stderr)
         return 3
-    if args.apply:
+    if (args.commit or args.commit_branch) and not args.apply:
         print(
-            "--apply is not implemented yet; see the --apply plan. Report works.",
+            "--commit needs --apply: there is nothing to commit until the plan "
+            "has been written",
             file=sys.stderr,
         )
         return 3
+    disp = [set(args.accept_upstream), set(args.retain), set(args.retain_unverified)]
+    for i, a in enumerate(disp):
+        for b in disp[i + 1 :]:
+            if a & b:
+                print(
+                    f"keys {sorted(a & b)} given more than one disposition; a key "
+                    "takes exactly one disposition",
+                    file=sys.stderr,
+                )
+                return 3
 
     try:
         cfg = replace(cfgmod.load_config(args.config), base_dirs=tuple(args.base_dirs))
@@ -78,26 +174,120 @@ def main(argv=None):
             pin=args.pin,
             pins=pins,
             accept_upstream=frozenset(args.accept_upstream),
+            retain=frozenset(args.retain),
+            retain_unverified=frozenset(args.retain_unverified),
             worktree_path=args.worktree_path,
-            apply=False,
+            apply=args.apply,
         )
 
         wt_path = args.worktree_path or worktree.default_path(args.defaults_dir, target)
-        # Report mode always removes the worktree: keep=False.
-        with worktree.session(args.defaults_dir, wt_path, base_ref) as (tree, base):
+        wrote = False
+        with worktree.session(
+            args.defaults_dir, wt_path, base_ref, keep=lambda: wrote
+        ) as (tree, base):
             plan = mirror_sync.build_plan(cfg, opts, tree, base)
-            if args.format == "json":
-                print(
-                    json.dumps(
-                        render.json_payload(plan, opts), indent=1, sort_keys=True
+            older = effective.effective_range(cfg, target)[:-1]
+            supply = classify.supply_info(cfg, tree)
+
+            # Raises on a stale disposition key, a failed retention gate, or
+            # --retain-unverified on a canonical gate. Reaches the handler below
+            # as exit 3 carrying its own diagnostic.
+            notes = gate.validate_dispositions(plan, opts, older, supply)
+
+            # Written before any emit path, including the apply refusal below:
+            # the values behind a refusal are exactly what the operator needs to
+            # resolve it, so they must not depend on the run succeeding.
+            report_path = Path(
+                args.report_file or f"sync-mirror-{target}.txt"
+            ).resolve()
+            report_path.write_text(detail.text(plan, opts), encoding="utf-8")
+
+            code = render.exit_code(plan, opts)
+            applied = None
+            result = None
+            committed = None
+            if args.apply:
+                if code != 1:
+                    # Refused. Nothing was written, so `wrote` stays False and
+                    # the session removes the worktree on the way out. applied is
+                    # explicitly False, not None: a consumer must be able to tell
+                    # "an apply was attempted and did not happen" from "this was a
+                    # report run", and null cannot express that.
+                    _emit(
+                        args.format,
+                        plan,
+                        opts,
+                        notes,
+                        applied=False,
+                        code=code,
+                        report_path=report_path,
                     )
-                )
-            else:
-                print(render.text(plan, opts), end="")
-            return render.exit_code(plan, opts)
+                    return code
+
+                def _started():
+                    nonlocal wrote
+                    wrote = True
+
+                try:
+                    result = write.apply_plan(plan, tree, on_first_write=_started)
+                except Exception as exc:  # noqa: BLE001 -- re-raised or reported
+                    if not wrote:
+                        raise  # nothing written; the generic handler is right
+                    # Something WAS written. The tree is kept deliberately, so the
+                    # operator has to be told where it is and how to clear it --
+                    # otherwise the next run refuses on an occupied path with a
+                    # message pointing at the wrong cause.
+                    print(
+                        f"{exc}\n\n"
+                        f"a partial write was left in {tree}\n"
+                        "inspect it, then remove it with:\n"
+                        f"  git -C {shlex.quote(str(args.defaults_dir))} "
+                        f"worktree remove {shlex.quote(str(tree))} --force",
+                        file=sys.stderr,
+                    )
+                    return 3
+                applied = True
+                if args.commit:
+                    branch = args.commit_branch or commit_mod.default_branch(target)
+                    sha = commit_mod.commit(
+                        tree,
+                        branch,
+                        target,
+                        render.commit_summary(plan, opts, notes),
+                        list(result["written"]) + list(result["deleted"]),
+                    )
+                    committed = (branch, sha)
+
+            _emit(
+                args.format,
+                plan,
+                opts,
+                notes,
+                applied=applied,
+                result=result,
+                code=0 if applied else code,
+                report_path=report_path,
+                committed=committed,
+                acceptance=(
+                    render.acceptance_command(
+                        tree,
+                        args.base_dirs,
+                        target=target,
+                        newest=sorted(enablement.release_range(cfg))[-1],
+                    )
+                    if applied
+                    else None
+                ),
+            )
+            # A successful apply is 0. Returning the pre-apply status would report
+            # 1 ("changes are ready to apply") for a run that just applied them.
+            return 0 if applied else code
     except (
         worktree.WorktreeError,  # base: exists / create / cleanup all map to 3
         layers.LayerError,  # base: monolithic / empty-layer / unowned-010
+        gate.GateError,  # base: unknown / wrong / mismatched / unparseable
+        commit_mod.CommitError,  # base: branch exists / git refused
+        write.WriteFailed,
         source.SourceError,
         cfgmod.ConfigError,
         ValueError,
@@ -106,6 +296,63 @@ def main(argv=None):
     ) as exc:
         print(str(exc), file=sys.stderr)
         return 3
+
+
+def _emit(
+    fmt,
+    plan,
+    opts,
+    notes,
+    applied=None,
+    result=None,
+    acceptance=None,
+    code=None,
+    report_path=None,
+    committed=None,
+):
+    """One emitter, so --format json stays a single parseable document.
+
+    Printing "applied: ..." alongside a JSON payload corrupts it for any consumer,
+    so everything extra becomes a field instead.
+    """
+    if fmt == "json":
+        payload = render.json_payload(plan, opts, applied=applied, notes=notes)
+        if result is not None:
+            payload["written"] = result["written"]
+            payload["deleted"] = result["deleted"]
+        if acceptance is not None:
+            payload["acceptance_command"] = acceptance
+        if report_path is not None:
+            payload["report_file"] = str(report_path)
+        if applied:
+            payload["commit_summary"] = render.commit_summary(plan, opts, notes)
+        if committed is not None:
+            payload["committed"] = {"branch": committed[0], "commit": committed[1]}
+        print(json.dumps(payload, indent=1, sort_keys=True))
+        return
+    print(
+        render.text(
+            plan, opts, notes, code=code, report_path=report_path, applied=applied
+        ),
+        end="",
+    )
+    if result is not None:
+        print(
+            f"\napplied: {len(result['written'])} written, "
+            f"{len(result['deleted'])} deleted"
+        )
+    if committed is not None:
+        branch, sha = committed
+        print(f"\ncommitted {sha[:12]} on {branch} in the worktree")
+        print(
+            "amend it to say why each semantic value was accepted or retained -- "
+            "the\nprovenance is generated, the reasoning is not"
+        )
+    elif applied:
+        print("\ncommit message block, for the commit that carries this apply:\n")
+        print(render.commit_summary(plan, opts, notes), end="")
+    if acceptance is not None:
+        print("\nverify with:\n" + acceptance)
 
 
 if __name__ == "__main__":

--- a/src/sync-mirror.py
+++ b/src/sync-mirror.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Report the per-release re-sync of osism/defaults' kolla mirror layer."""
+
+import argparse
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from osism_drift import config as cfgmod  # noqa: E402
+from osism_drift import enablement, mirror_sync, source  # noqa: E402
+from osism_drift.mirror_sync import layers, effective, render, worktree  # noqa: E402
+from osism_drift.mirror_sync.model import SyncOpts  # noqa: E402
+
+here = Path(__file__).resolve().parent
+_DEFAULT_BASE_REF = "origin/main"
+
+
+def _parser():
+    p = argparse.ArgumentParser(
+        description="Report the re-sync of osism/defaults' kolla mirror for a release."
+    )
+    p.add_argument("--config", default=str(here / "drift-config.yml"))
+    p.add_argument("--target", help="release to mirror; default newest supported")
+    p.add_argument(
+        "--defaults-dir", help="osism/defaults checkout (required in both modes)"
+    )
+    p.add_argument("--base-dir", action="append", default=[], dest="base_dirs")
+    p.add_argument("--base-ref", default=_DEFAULT_BASE_REF)
+    p.add_argument("--pin", help="upstream commit for --target")
+    p.add_argument("--pins-from", help="report.json to replay every pin from")
+    # --accept-upstream only. --retain / --retain-unverified arrive with --apply,
+    # which owns the canonical-gate parser that gives them meaning; accepting
+    # them here would let a run report "all dispositioned" without the checks.
+    p.add_argument("--accept-upstream", action="append", default=[])
+    p.add_argument("--worktree-path")
+    p.add_argument("--apply", action="store_true")
+    p.add_argument("--format", choices=("text", "json"), default="text")
+    return p
+
+
+def main(argv=None):
+    args = _parser().parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not args.defaults_dir:
+        print("--defaults-dir is required", file=sys.stderr)
+        return 3
+    if args.apply:
+        print(
+            "--apply is not implemented yet; see the --apply plan. Report works.",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        cfg = replace(cfgmod.load_config(args.config), base_dirs=tuple(args.base_dirs))
+        target = args.target or sorted(enablement.release_range(cfg))[-1]
+
+        pins, base_ref = {}, args.base_ref
+        if args.pins_from:
+            if args.base_ref != _DEFAULT_BASE_REF:
+                print(
+                    "--pins-from carries the defaults base commit; "
+                    "--base-ref conflicts with it",
+                    file=sys.stderr,
+                )
+                return 3
+            payload = json.loads(Path(args.pins_from).read_text(encoding="utf-8"))
+            pins, base_ref = effective.validate_pins_payload(
+                payload, target, effective.effective_range(cfg, target)
+            )
+
+        opts = SyncOpts(
+            target=target,
+            base_ref=base_ref,
+            pin=args.pin,
+            pins=pins,
+            accept_upstream=frozenset(args.accept_upstream),
+            worktree_path=args.worktree_path,
+            apply=False,
+        )
+
+        wt_path = args.worktree_path or worktree.default_path(args.defaults_dir, target)
+        # Report mode always removes the worktree: keep=False.
+        with worktree.session(args.defaults_dir, wt_path, base_ref) as (tree, base):
+            plan = mirror_sync.build_plan(cfg, opts, tree, base)
+            if args.format == "json":
+                print(
+                    json.dumps(
+                        render.json_payload(plan, opts), indent=1, sort_keys=True
+                    )
+                )
+            else:
+                print(render.text(plan, opts), end="")
+            return render.exit_code(plan, opts)
+    except (
+        worktree.WorktreeError,  # base: exists / create / cleanup all map to 3
+        layers.LayerError,  # base: monolithic / empty-layer / unowned-010
+        source.SourceError,
+        cfgmod.ConfigError,
+        ValueError,
+        KeyError,
+        OSError,
+    ) as exc:
+        print(str(exc), file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/mirror_sync/conftest.py
+++ b/tests/mirror_sync/conftest.py
@@ -1,0 +1,7 @@
+"""Shared test config: makes src/ importable as `osism_drift`."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))

--- a/tests/mirror_sync/test_attribute.py
+++ b/tests/mirror_sync/test_attribute.py
@@ -1,0 +1,206 @@
+import subprocess
+
+from osism_drift.mirror_sync import attribute
+
+
+def _git(d, *a):
+    subprocess.run(["git", "-C", str(d), *a], check=True, capture_output=True)
+
+
+def _rev(d):
+    return subprocess.run(
+        ["git", "-C", str(d), "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path):
+    """A kolla-ansible stand-in whose group_vars change over three commits."""
+    d = tmp_path / "kolla-ansible"
+    (d / "ansible/group_vars/all").mkdir(parents=True)
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    gv = d / "ansible/group_vars/all"
+    (gv / "common.yml").write_text('om_rabbitmq_qos_prefetch_count: "1"\n')
+    (gv / "rabbitmq.yml").write_text("rabbitmq_monitoring_user: ''\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    lo = _rev(d)
+    (gv / "common.yml").write_text('om_rabbitmq_qos_prefetch_count: "50"\n')
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "rabbitmq: Bump prefetch 1 to 50")
+    (gv / "rabbitmq.yml").write_text("rabbitmq_monitoring_user: 'openstack'\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "haproxy: fix missing user in healthcheck")
+    hi = _rev(d)
+    return d, lo, hi
+
+
+def _local(monkeypatch, d):
+    monkeypatch.setattr(attribute.source, "local_checkout", lambda repo, cfg: d)
+
+
+def test_finds_the_commit_that_changed_the_key(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    lines, note = attribute.commits_for(
+        None, "om_rabbitmq_qos_prefetch_count", ["common.yml"], lo, hi
+    )
+    assert note == ""
+    assert any("Bump prefetch" in line for line in lines)
+    assert not any("healthcheck" in line for line in lines)
+
+
+def test_searches_both_old_and_new_homes(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    # A key that moved files: the union must cover both, since searching only the
+    # post-sync home can miss the commit that made the change.
+    lines, _ = attribute.commits_for(
+        None, "rabbitmq_monitoring_user", ["common.yml", "rabbitmq.yml"], lo, hi
+    )
+    assert any("healthcheck" in line for line in lines)
+
+
+def test_a_missing_home_does_not_break_the_union(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    lines, _ = attribute.commits_for(
+        None, "om_rabbitmq_qos_prefetch_count", ["gone.yml", "common.yml"], lo, hi
+    )
+    assert any("Bump prefetch" in line for line in lines)
+
+
+def test_key_is_regex_escaped(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    # git log -G takes a PATTERN; unescaped, "a.*b" would match unrelated diffs.
+    lines, note = attribute.commits_for(None, "a.*b", ["common.yml"], lo, hi)
+    assert lines == ()
+
+
+def test_range_is_bounded_below(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    # lo..hi excludes the base commit that first introduced the key, so an
+    # unbounded search would report a commit predating this transition.
+    lines, _ = attribute.commits_for(
+        None, "om_rabbitmq_qos_prefetch_count", ["common.yml"], lo, hi
+    )
+    assert not any("base" in line for line in lines)
+
+
+def test_cap_is_globally_newest_first_across_homes(tmp_path, monkeypatch):
+    """The cap must respect global order, not per-home order.
+
+    Running one log per home and concatenating yields the first home's two newest
+    commits and drops a newer commit in the second home -- while the note claims
+    to show the newest two. Verified against real git: concatenated gives
+    (a2, a1); one invocation gives (b2, a2).
+    """
+    d = tmp_path / "kolla-ansible"
+    gv = d / "ansible/group_vars/all"
+    gv.mkdir(parents=True)
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    (gv / "a.yml").write_text("churn: 0\n")
+    (gv / "b.yml").write_text("churn: 0\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    lo = _rev(d)
+    for i in (1, 2):
+        (gv / "a.yml").write_text(f"churn: a{i}\n")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-qm", f"a change {i}")
+        (gv / "b.yml").write_text(f"churn: b{i}\n")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-qm", f"b change {i}")
+    hi = _rev(d)
+    _local(monkeypatch, d)
+
+    lines, note = attribute.commits_for(
+        None, "churn", ["a.yml", "b.yml"], lo, hi, cap=2
+    )
+    assert "truncated" in note
+    subjects = [line.split(" ", 1)[1] for line in lines]
+    assert subjects == ["b change 2", "a change 2"]
+
+
+def test_a_commit_touching_both_homes_is_not_listed_twice(tmp_path, monkeypatch):
+    d = tmp_path / "kolla-ansible"
+    gv = d / "ansible/group_vars/all"
+    gv.mkdir(parents=True)
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    (gv / "a.yml").write_text("churn: 0\n")
+    (gv / "b.yml").write_text("churn: 0\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    lo = _rev(d)
+    (gv / "a.yml").write_text("churn: 1\n")
+    (gv / "b.yml").write_text("churn: 1\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "both at once")
+    hi = _rev(d)
+    _local(monkeypatch, d)
+    lines, _ = attribute.commits_for(None, "churn", ["a.yml", "b.yml"], lo, hi)
+    assert len(lines) == 1
+
+
+def test_a_git_failure_is_reported_not_silently_empty(tmp_path, monkeypatch):
+    # An empty list with no note reads as "nothing changed this key", which is a
+    # different answer from "attribution could not be computed".
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    lines, note = attribute.commits_for(
+        None, "om_rabbitmq_qos_prefetch_count", ["common.yml"], "not-a-ref", hi
+    )
+    assert lines == ()
+    assert "attribution failed" in note
+
+
+def test_no_known_home_is_reported_not_silently_empty(tmp_path, monkeypatch):
+    d, lo, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    lines, note = attribute.commits_for(None, "k", [], lo, hi)
+    assert lines == ()
+    assert "no upstream path" in note
+
+
+def test_remote_only_run_skips_with_a_stated_reason(monkeypatch):
+    monkeypatch.setattr(attribute.source, "local_checkout", lambda repo, cfg: None)
+    lines, note = attribute.commits_for(None, "k", ["common.yml"], "a" * 40, "b" * 40)
+    assert lines == ()
+    assert "local checkout" in note
+
+
+def test_missing_range_skips_with_a_stated_reason(tmp_path, monkeypatch):
+    d, _, hi = _repo(tmp_path)
+    _local(monkeypatch, d)
+    lines, note = attribute.commits_for(None, "k", ["common.yml"], None, hi)
+    assert lines == ()
+    assert "range" in note
+
+
+def test_results_are_capped_and_say_so(tmp_path, monkeypatch):
+    d = tmp_path / "kolla-ansible"
+    (d / "ansible/group_vars/all").mkdir(parents=True)
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    gv = d / "ansible/group_vars/all"
+    (gv / "common.yml").write_text("churn: 0\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    lo = _rev(d)
+    for i in range(1, 8):
+        (gv / "common.yml").write_text(f"churn: {i}\n")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-qm", f"change {i}")
+    hi = _rev(d)
+    _local(monkeypatch, d)
+    lines, note = attribute.commits_for(None, "churn", ["common.yml"], lo, hi, cap=3)
+    assert len(lines) == 3
+    assert "truncated" in note

--- a/tests/mirror_sync/test_classify.py
+++ b/tests/mirror_sync/test_classify.py
@@ -1,0 +1,182 @@
+from osism_drift.mirror_sync import classify
+
+
+def _supply(**keys):
+    return keys
+
+
+# --- representation: the explicit truth table -------------------------------
+
+
+def test_quoted_no_vs_false_is_representation_not_semantic():
+    # bool("no") is True in Python, so a naive implementation calls this a truth
+    # change. Upstream's 2026.1 edit was quoted -> bare, so all 112 rows land here.
+    cls, note = classify.classify("k", "no", False, _supply())
+    assert cls == "representation"
+    assert "only the YAML type or spelling differs" in note
+
+
+def test_yes_vs_true_is_representation():
+    assert classify.classify("k", "yes", True, _supply())[0] == "representation"
+
+
+def test_on_off_tokens_are_covered():
+    assert classify.classify("k", "on", True, _supply())[0] == "representation"
+    assert classify.classify("k", "off", False, _supply())[0] == "representation"
+
+
+def test_token_match_is_case_insensitive():
+    assert classify.classify("k", "No", False, _supply())[0] == "representation"
+
+
+def test_opposite_truth_values_are_semantic():
+    assert classify.classify("k", "yes", False, _supply())[0] == "semantic"
+
+
+def test_a_non_boolish_string_is_not_representation():
+    assert classify.classify("k", "maybe", False, _supply())[0] == "semantic"
+
+
+# --- notation: narrow, enumerated normalization ------------------------------
+
+
+def test_jinja_delimiter_whitespace_only_is_notation():
+    old = "{{ a }}://{% if not loop.last %},{% endif %}"
+    new = "{{a}}://{%if not loop.last %},{% endif %}"
+    assert classify.classify("k", old, new, _supply())[0] == "notation"
+
+
+def test_whitespace_inside_a_jinja_expression_stays_semantic():
+    # Collapsing inside an expression can alter a string literal; refuse to.
+    assert classify.classify("k", "{{ 'a b' }}", "{{ 'ab' }}", _supply())[0] == (
+        "semantic"
+    )
+
+
+def test_a_changed_filter_argument_stays_semantic():
+    old = "{{ x | join(':') }}"
+    new = "{{ x | join(' ') }}"
+    assert classify.classify("k", old, new, _supply())[0] == "semantic"
+
+
+# --- overridden: narrowed, by lexical position ------------------------------
+
+
+def test_overridden_requires_an_unconditional_later_layer():
+    info = {"k": {"layers": ["all/099-kolla.yml"], "value": "monitoring"}}
+    assert classify.classify("k", "", "openstack-monitoring", info)[0] == "overridden"
+
+
+def test_a_100_layer_counts_as_unconditional():
+    # all/100-ansible.yml is real, global, and sorts after the 001-* mirror. An
+    # earlier draft gated on an "all/0" prefix and silently excluded it.
+    info = {"k": {"layers": ["all/100-ansible.yml"], "value": "plain"}}
+    assert classify.classify("k", 1, 2, info)[0] == "overridden"
+
+
+def test_a_010_layer_does_not_count():
+    info = {"k": {"layers": ["all/010-2025.1.yml"], "value": "plain"}}
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_a_layer_sorting_before_the_mirror_does_not_count():
+    info = {"k": {"layers": ["all/000-early.yml"], "value": "plain"}}
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_release_conditional_override_is_not_overridden():
+    # A gate applies per release, so it does not prove the change cannot land.
+    info = {
+        "k": {
+            "layers": ["all/099-kolla.yml"],
+            "value": "{{ 'a' if openstack_version in ['2024.1'] else 'b' }}",
+        }
+    }
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_a_release_gate_nested_in_a_mapping_is_not_overridden():
+    # The gate need not be the whole value: a later layer may supply a dict whose
+    # nested string carries it, and calling that unconditional would wave a real
+    # per-release change through as non-gating.
+    info = {
+        "k": {
+            "layers": ["all/099-kolla.yml"],
+            "value": {
+                "nested": "{{ 'old' if openstack_version in ['2025.2'] else 'new' }}"
+            },
+        }
+    }
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_a_release_gate_nested_in_a_list_is_not_overridden():
+    info = {
+        "k": {
+            "layers": ["all/099-kolla.yml"],
+            "value": ["plain", "{{ 'a' if openstack_release in ['2025.1'] else 'b' }}"],
+        }
+    }
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_a_release_gate_nested_two_levels_deep_is_not_overridden():
+    info = {
+        "k": {
+            "layers": ["all/100-ansible.yml"],
+            "value": {"outer": [{"inner": "{{ 'a' if openstack_version in [] }}"}]},
+        }
+    }
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_a_plain_mapping_override_is_still_overridden():
+    # Recursion must not make every structured value look conditional.
+    info = {"k": {"layers": ["all/099-kolla.yml"], "value": {"a": 1, "b": [2, 3]}}}
+    assert classify.classify("k", 1, 2, info)[0] == "overridden"
+
+
+def test_overlay_only_supply_is_not_overridden():
+    info = {"k": {"layers": ["overlay:2025.2"], "value": "x"}}
+    assert classify.classify("k", 1, 2, info)[0] == "semantic"
+
+
+def test_versions_yml_is_the_named_exception():
+    # openstack_release: "{{ openstack_version }}" is Jinja but unconditional and
+    # global -- the file is generated per deployment and sorts after every 001-*.
+    info = {"k": {"layers": ["versions.yml"], "value": "{{ openstack_version }}"}}
+    assert classify.classify("k", "2025.2", "2026.1", info)[0] == "overridden"
+
+
+# --- supply_info: the layer map must include versions.yml for real ----------
+
+
+def test_supply_info_reads_the_defaults_layers_with_last_wins(tmp_path, monkeypatch):
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-nova.yml").write_bytes(b"mirrored: 1\n")  # mirror is excluded
+    (allsrc / "099-a.yml").write_bytes(b"shared: first\n")
+    (allsrc / "099-b.yml").write_bytes(b"shared: second\n")
+    monkeypatch.setattr(classify.source, "read", lambda repo, path, cfg: b"")
+    info = classify.supply_info(None, tmp_path)
+    assert "mirrored" not in info
+    assert info["shared"]["layers"] == ["all/099-a.yml", "all/099-b.yml"]
+    assert info["shared"]["value"] == "second"  # lexically last wins
+
+
+def test_supply_info_includes_the_rendered_versions_layer(tmp_path, monkeypatch):
+    # Regression: an earlier design globbed defaults/all/*.yml only, so the
+    # versions.yml exception could never fire in a real run and openstack_release
+    # -- the one key it exists for -- came out semantic.
+    (tmp_path / "all").mkdir()
+    monkeypatch.setattr(
+        classify.source,
+        "read",
+        lambda repo, path, cfg: b'openstack_release: "{{ openstack_version }}"\n',
+    )
+    info = classify.supply_info(None, tmp_path)
+    assert "versions.yml" in info["openstack_release"]["layers"]
+    # and it must actually classify as overridden through that layer
+    assert classify.classify("openstack_release", "2025.2", "2026.1", info)[0] == (
+        "overridden"
+    )

--- a/tests/mirror_sync/test_cli.py
+++ b/tests/mirror_sync/test_cli.py
@@ -1,7 +1,6 @@
 import importlib.util
+import json
 from pathlib import Path
-
-import pytest
 
 SRC = Path(__file__).resolve().parents[2] / "src" / "sync-mirror.py"
 
@@ -21,17 +20,216 @@ def test_report_mode_also_requires_defaults_dir(capsys):
     assert "--defaults-dir is required" in capsys.readouterr().err
 
 
-def test_apply_is_not_available_yet(capsys):
-    rc = _load().main(["--target", "2025.2", "--defaults-dir", "/tmp", "--apply"])
+def _ready_plan():
+    """A Plan that yields exit 1 -- changes present, nothing to dispose."""
+    from osism_drift.mirror_sync.model import Plan
+
+    return Plan(
+        target_release="2025.2",
+        release_shas={"2025.2": "a" * 40},
+        defaults_base_sha="d" * 40,
+        prev_release=None,
+        range_base_sha=None,
+        mirror_writes={"all/001-nova.yml": b"x\n"},
+        mirror_deletes=(),
+        compat_writes={},
+        compat_deletes=(),
+        changed_writes=("all/001-nova.yml",),
+        created_paths=(),
+        rows=(),
+        added_keys=(),
+        dropped_keys={},
+        added_files=(),
+        deleted_files=(),
+        unowned_compat=(),
+    )
+
+
+class _Session:
+    def __init__(self, tree):
+        self._tree = tree
+
+    def __enter__(self):
+        return self._tree, "d" * 40
+
+    def __exit__(self, *a):
+        return False
+
+
+def _apply_harness(mod, monkeypatch, tree, cwd=None):
+    """Stub every outward call the apply path makes.
+
+    `cwd` moves the default report file out of the repo: --report-file defaults to
+    ./sync-mirror-<target>.txt, so without it the suite writes into the checkout.
+
+    effective_range() and release_range() both glob latest/openstack-*.yml through
+    `source`, which with no --base-dir means a live GitHub request. Without these
+    two the tests pass on a networked machine and fail in offline CI -- verified by
+    running them behind a dead proxy.
+    """
+    monkeypatch.setattr(mod.worktree, "session", lambda *a, **k: _Session(tree))
+    monkeypatch.setattr(mod.mirror_sync, "build_plan", lambda *a, **k: _ready_plan())
+    monkeypatch.setattr(mod.classify, "supply_info", lambda *a, **k: {})
+    monkeypatch.setattr(mod.gate, "validate_dispositions", lambda *a, **k: {})
+    monkeypatch.setattr(
+        mod.effective, "effective_range", lambda cfg, target: ["2025.1", "2025.2"]
+    )
+    monkeypatch.setattr(
+        mod.enablement, "release_range", lambda cfg: ["2025.1", "2025.2"]
+    )
+    if cwd is not None:
+        monkeypatch.chdir(cwd)
+
+
+def test_the_same_key_under_two_dispositions_is_an_error(tmp_path, capsys):
+    rc = _load().main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--retain",
+            "k",
+            "--accept-upstream",
+            "k",
+        ]
+    )
     assert rc == 3
-    assert "not implemented" in capsys.readouterr().err
+    assert "one disposition" in capsys.readouterr().err
 
 
-def test_retain_flags_are_not_accepted_in_this_build():
-    # They arrive with --apply; argparse must reject them here rather than
-    # letting a run report "all dispositioned" without the gate parser.
-    with pytest.raises(SystemExit):
-        _load().main(["--target", "2025.2", "--defaults-dir", "/tmp", "--retain", "k"])
+def test_keep_is_decided_at_exit_not_entry(tmp_path, monkeypatch):
+    """A refused apply must not leave the worktree behind.
+
+    keep=args.apply would retain it for a run blocked on a missing disposition,
+    occupying the default path so the NEXT run refuses on it.
+    """
+    mod = _load()
+    seen = {}
+
+    def fake_session(defaults_dir, path, base_ref, keep=False):
+        seen["keep"] = keep
+        raise mod.worktree.CreateFailed("stop")
+
+    monkeypatch.setattr(mod.worktree, "session", fake_session)
+    mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path), "--apply"])
+    assert callable(seen["keep"]), "keep must be evaluated at exit"
+    assert seen["keep"]() is False, "nothing written yet, so do not keep"
+
+
+def test_a_midwrite_failure_names_the_worktree_and_how_to_remove_it(
+    tmp_path, monkeypatch, capsys
+):
+    """The tree is kept on purpose, so the operator must be told where it is."""
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+
+    def boom(plan, tree, on_first_write=None):
+        on_first_write()  # mutation began
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(mod.write, "apply_plan", boom)
+    rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path), "--apply"])
+    err = capsys.readouterr().err
+    assert rc == 3
+    assert "No space left on device" in err
+    assert "partial write" in err
+    assert "worktree remove" in err and str(wt) in err
+
+
+def test_a_failure_before_any_write_does_not_claim_a_partial_write(
+    tmp_path, monkeypatch, capsys
+):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    monkeypatch.setattr(
+        mod.write,
+        "apply_plan",
+        lambda plan, tree, on_first_write=None: (_ for _ in ()).throw(
+            mod.write.WriteFailed("bad path")
+        ),
+    )
+    rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path), "--apply"])
+    err = capsys.readouterr().err
+    assert rc == 3
+    assert "bad path" in err
+    assert "partial write" not in err
+
+
+def test_a_successful_apply_returns_zero_and_emits_one_json_document(
+    tmp_path, monkeypatch, capsys
+):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    monkeypatch.setattr(
+        mod.write,
+        "apply_plan",
+        lambda plan, tree, on_first_write=None: (
+            on_first_write(),
+            {"written": ["all/001-nova.yml"], "deleted": []},
+        )[1],
+    )
+    rc = mod.main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--apply",
+            "--format",
+            "json",
+        ]
+    )
+    out = capsys.readouterr().out
+    # 0, not the pre-apply 1: the changes are no longer "ready to apply".
+    assert rc == 0
+    payload = json.loads(out)  # one document, not JSON followed by prose
+    assert payload["applied"] is True
+    assert payload["written"] == ["all/001-nova.yml"]
+    assert "acceptance_command" in payload
+
+
+def test_a_refused_apply_reports_applied_false_not_null(tmp_path, monkeypatch, capsys):
+    """Three states, three values.
+
+    null means "report run"; False means "an apply was attempted and did not
+    happen". Collapsing them leaves a consumer unable to tell the difference.
+    """
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    monkeypatch.setattr(mod.render, "exit_code", lambda *a, **k: 2)
+    rc = mod.main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--apply",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 2
+    assert json.loads(capsys.readouterr().out)["applied"] is False
+
+
+def test_a_report_run_reports_applied_null(tmp_path, monkeypatch, capsys):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    mod.main(
+        ["--target", "2025.2", "--defaults-dir", str(tmp_path), "--format", "json"]
+    )
+    assert json.loads(capsys.readouterr().out)["applied"] is None
 
 
 def test_worktree_failures_exit_3(tmp_path, monkeypatch, capsys):
@@ -87,3 +285,104 @@ def test_pins_from_conflicting_with_base_ref_is_an_error(tmp_path, capsys):
     )
     assert rc == 3
     assert "conflicts" in capsys.readouterr().err
+
+
+def test_the_report_file_is_written_by_default_and_named_in_the_output(
+    tmp_path, monkeypatch, capsys
+):
+    """The terminal elides values, so the file it points at has to exist."""
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path)])
+    report = tmp_path / "sync-mirror-2025.2.txt"
+    assert rc == 1
+    assert report.exists()
+    assert "sync-mirror detail report" in report.read_text(encoding="utf-8")
+    assert str(report) in capsys.readouterr().out
+
+
+def test_report_file_honours_an_explicit_path(tmp_path, monkeypatch, capsys):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    chosen = tmp_path / "elsewhere.txt"
+    mod.main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--report-file",
+            str(chosen),
+        ]
+    )
+    assert chosen.exists()
+    assert not (tmp_path / "sync-mirror-2025.2.txt").exists()
+
+
+def test_a_refused_apply_still_leaves_the_report_behind(tmp_path, monkeypatch, capsys):
+    """The values behind a refusal are exactly what is needed to resolve it."""
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    monkeypatch.setattr(mod.render, "exit_code", lambda *a, **k: 2)
+    rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path), "--apply"])
+    assert rc == 2
+    assert (tmp_path / "sync-mirror-2025.2.txt").exists()
+
+
+def test_json_names_the_report_file_so_a_consumer_can_find_it(
+    tmp_path, monkeypatch, capsys
+):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    mod.main(
+        ["--target", "2025.2", "--defaults-dir", str(tmp_path), "--format", "json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_file"].endswith("sync-mirror-2025.2.txt")
+
+
+def test_commit_without_apply_is_refused(tmp_path, capsys):
+    """--commit alone would silently do nothing: there is no plan on disk yet."""
+    rc = _load().main(
+        ["--target", "2025.2", "--defaults-dir", str(tmp_path), "--commit"]
+    )
+    assert rc == 3
+    assert "--commit needs --apply" in capsys.readouterr().err
+
+
+def test_commit_branch_without_apply_is_refused_too(tmp_path, capsys):
+    rc = _load().main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--commit-branch",
+            "whatever",
+        ]
+    )
+    assert rc == 3
+    assert "--commit needs --apply" in capsys.readouterr().err
+
+
+def test_apply_reports_the_branch_and_commit_it_made(tmp_path, monkeypatch, capsys):
+    mod = _load()
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    _apply_harness(mod, monkeypatch, wt, cwd=tmp_path)
+    monkeypatch.setattr(mod.commit_mod, "commit", lambda *a, **k: "c" * 40)
+    rc = mod.main(
+        ["--target", "2025.2", "--defaults-dir", str(tmp_path), "--apply", "--commit"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "committed cccccccccccc on sync-mirror/2025.2 in the worktree" in out
+    assert "the reasoning is not" in out

--- a/tests/mirror_sync/test_cli.py
+++ b/tests/mirror_sync/test_cli.py
@@ -1,0 +1,89 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "sync-mirror.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("sync_mirror_cli", SRC)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_report_mode_also_requires_defaults_dir(capsys):
+    # Report reads a worktree of this repo, so there is no mode where it is
+    # optional -- and passing None through would reach Path(None) instead.
+    rc = _load().main(["--target", "2025.2"])
+    assert rc == 3
+    assert "--defaults-dir is required" in capsys.readouterr().err
+
+
+def test_apply_is_not_available_yet(capsys):
+    rc = _load().main(["--target", "2025.2", "--defaults-dir", "/tmp", "--apply"])
+    assert rc == 3
+    assert "not implemented" in capsys.readouterr().err
+
+
+def test_retain_flags_are_not_accepted_in_this_build():
+    # They arrive with --apply; argparse must reject them here rather than
+    # letting a run report "all dispositioned" without the gate parser.
+    with pytest.raises(SystemExit):
+        _load().main(["--target", "2025.2", "--defaults-dir", "/tmp", "--retain", "k"])
+
+
+def test_worktree_failures_exit_3(tmp_path, monkeypatch, capsys):
+    # Unit-testing worktree.CleanupFailed is not enough: the CLI must map the whole
+    # category to the documented status instead of letting a traceback exit 1.
+    mod = _load()
+    for exc, msg in (
+        (mod.worktree.CleanupFailed, "stuck"),
+        (mod.worktree.CreateFailed, "no HEAD"),
+        (mod.worktree.WorktreeExists, "occupied"),
+    ):
+        monkeypatch.setattr(
+            mod.worktree,
+            "session",
+            lambda *a, exc=exc, msg=msg, **k: (_ for _ in ()).throw(exc(msg)),
+        )
+        rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path)])
+        assert rc == 3
+        assert msg in capsys.readouterr().err
+
+
+def test_arms_failures_exit_3(tmp_path, monkeypatch, capsys):
+    mod = _load()
+    for exc, msg in (
+        (mod.layers.MonolithicLayout, "monolithic"),
+        (mod.layers.EmptyUpstreamLayer, "listed no"),
+        (mod.layers.UnownedCompatFile, "no marker"),
+    ):
+        monkeypatch.setattr(
+            mod.worktree,
+            "session",
+            lambda *a, exc=exc, msg=msg, **k: (_ for _ in ()).throw(exc(msg)),
+        )
+        rc = mod.main(["--target", "2025.2", "--defaults-dir", str(tmp_path)])
+        assert rc == 3
+        assert msg in capsys.readouterr().err
+
+
+def test_pins_from_conflicting_with_base_ref_is_an_error(tmp_path, capsys):
+    report = tmp_path / "r.json"
+    report.write_text('{"schema": 1}')
+    rc = _load().main(
+        [
+            "--target",
+            "2025.2",
+            "--defaults-dir",
+            str(tmp_path),
+            "--pins-from",
+            str(report),
+            "--base-ref",
+            "some-branch",
+        ]
+    )
+    assert rc == 3
+    assert "conflicts" in capsys.readouterr().err

--- a/tests/mirror_sync/test_commit.py
+++ b/tests/mirror_sync/test_commit.py
@@ -1,0 +1,85 @@
+"""--commit: the mechanical step after every judgement has been made."""
+
+import subprocess
+
+import pytest
+
+from osism_drift.mirror_sync import commit
+
+
+def _repo(path):
+    def git(*args, **kw):
+        return subprocess.run(
+            ["git", "-C", str(path), *args], capture_output=True, check=True, **kw
+        )
+
+    path.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main")
+    git("config", "user.name", "A Tester")
+    git("config", "user.email", "tester@example.invalid")
+    git("config", "commit.gpgsign", "false")
+    (path / "keep.txt").write_text("x\n")
+    git("add", "keep.txt")
+    git("commit", "-q", "-m", "base", env={"PATH": "/usr/bin:/bin", "HOME": str(path)})
+    return git
+
+
+def test_commit_branches_stages_and_returns_the_sha(tmp_path):
+    tree = tmp_path / "wt"
+    git = _repo(tree)
+    (tree / "written.yml").write_text("a: 1\n")
+    sha = commit.commit(
+        tree, "sync-mirror/2026.1", "2026.1", "PROVENANCE\n", ["written.yml"]
+    )
+    assert len(sha) == 40
+    assert git("branch", "--show-current").stdout.decode().strip() == (
+        "sync-mirror/2026.1"
+    )
+    body = git("log", "-1", "--format=%B").stdout.decode()
+    assert body.startswith("kolla: re-sync the mirror layer for 2026.1\n")
+    assert "PROVENANCE" in body
+    assert "Signed-off-by: A Tester <tester@example.invalid>" in body
+    assert git("status", "--porcelain").stdout.decode().strip() == ""
+
+
+def test_commit_stages_a_deletion(tmp_path):
+    """A path the plan deleted has to reach the commit as a deletion."""
+    tree = tmp_path / "wt"
+    git = _repo(tree)
+    (tree / "gone.yml").write_text("a: 1\n")
+    git("add", "gone.yml")
+    git("commit", "-q", "-m", "add gone")
+    (tree / "gone.yml").unlink()
+    commit.commit(tree, "b", "2026.1", "P\n", ["gone.yml"])
+    files = git("show", "--stat", "--format=", "HEAD").stdout.decode()
+    assert "gone.yml" in files
+    assert git("status", "--porcelain").stdout.decode().strip() == ""
+
+
+def test_an_existing_branch_is_refused_not_moved(tmp_path):
+    tree = tmp_path / "wt"
+    git = _repo(tree)
+    git("branch", "taken")
+    (tree / "written.yml").write_text("a: 1\n")
+    with pytest.raises(commit.BranchExists):
+        commit.commit(tree, "taken", "2026.1", "P\n", ["written.yml"])
+
+
+def test_signoff_requires_an_identity(tmp_path, monkeypatch):
+    """Without it the eventual PR fails the DCO gate, so refuse early.
+
+    The lookup is stubbed rather than unset in the repo: `git config user.email`
+    falls back to the global file, so a --local --unset proves nothing here.
+    """
+
+    class _Empty:
+        stdout = b"\n"
+        returncode = 0
+
+    monkeypatch.setattr(commit, "_git", lambda *a, **k: _Empty())
+    with pytest.raises(commit.CommitError, match="user.name and user.email"):
+        commit.signoff(tmp_path)
+
+
+def test_default_branch_is_named_for_the_target():
+    assert commit.default_branch("2026.1") == "sync-mirror/2026.1"

--- a/tests/mirror_sync/test_detail.py
+++ b/tests/mirror_sync/test_detail.py
@@ -1,0 +1,79 @@
+"""The detail report: the values the terminal deliberately does not print."""
+
+from osism_drift.mirror_sync import detail
+from osism_drift.mirror_sync.model import Plan, Row, SyncOpts
+
+
+def _plan(**kw):
+    base = dict(
+        target_release="2026.1",
+        release_shas={"2025.2": "a" * 40, "2026.1": "b" * 40},
+        defaults_base_sha="d" * 40,
+        prev_release="2025.2",
+        range_base_sha="c" * 40,
+        mirror_writes={},
+        mirror_deletes=(),
+        compat_writes={},
+        compat_deletes=(),
+        unowned_compat=(),
+        changed_writes=(),
+        created_paths=(),
+        rows=(
+            Row("k_sem", "{{ a }}", "{{\n  a\n}}", "semantic", ("abc123 Re-wrap",), ""),
+            Row("k_rep", "no", False, "representation", (), "not proven inert"),
+        ),
+        added_keys=("_ssl_modern_options",),
+        dropped_keys={"enable_zun": "all/010-2025.2.yml"},
+        added_files=("all/001-valkey.yml",),
+        deleted_files=("all/001-zun.yml",),
+    )
+    base.update(kw)
+    return Plan(**base)
+
+
+def test_multiline_value_is_written_with_real_newlines():
+    """The whole point: repr() turns a re-wrap into one line of \\n escapes."""
+    out = detail.text(_plan())
+    assert "\\n" not in out
+    assert "     {{\n       a\n     }}" in out
+
+
+def test_quoting_is_preserved_for_short_values():
+    """'no' -> False is the representation class; str() would hide the difference."""
+    out = detail.text(_plan())
+    assert "     'no'" in out
+    assert "     False" in out
+
+
+def test_each_class_carries_its_meaning():
+    out = detail.text(_plan())
+    assert "semantic (1)" in out
+    assert "each key needs a disposition" in out
+    assert "representation (1)" in out
+    assert "byte-for-byte mirror" in out
+
+
+def test_attribution_and_note_travel_with_the_row():
+    out = detail.text(_plan())
+    assert "upstream: abc123 Re-wrap" in out
+    assert "not proven inert" in out
+
+
+def test_header_names_the_base_ref_and_both_shas():
+    out = detail.text(_plan(), SyncOpts(target="2026.1", base_ref="my-branch"))
+    assert f"target        2026.1 @ {'b' * 40}" in out
+    assert f"defaults base my-branch @ {'d' * 40}" in out
+
+
+def test_files_and_keys_the_terminal_truncates_are_all_here():
+    out = detail.text(_plan())
+    assert "+ all/001-valkey.yml" in out
+    assert "- all/001-zun.yml" in out
+    assert "_ssl_modern_options" in out
+    assert "enable_zun -> all/010-2025.2.yml" in out
+
+
+def test_a_class_with_no_rows_gets_no_section():
+    out = detail.text(_plan(rows=()))
+    assert "semantic" not in out
+    assert "notation" not in out

--- a/tests/mirror_sync/test_effective.py
+++ b/tests/mirror_sync/test_effective.py
@@ -1,0 +1,203 @@
+import pytest
+from osism_drift.config import Config, Remote, SourceCfg
+from osism_drift.mirror_sync import effective
+from osism_drift.mirror_sync.model import SyncOpts
+
+
+def _cfg(tmp_path, releases=("2024.1", "2025.1", "2025.2", "2026.1")):
+    rel = tmp_path / "release" / "latest"
+    rel.mkdir(parents=True)
+    for r in releases:
+        (rel / f"openstack-{r}.yml").write_text("openstack_projects: {cinder: x}\n")
+    return Config(
+        remote=Remote("https://raw/", "https://api/", "main", "osism"),
+        release_version="latest",
+        plugins={},
+        sources={"kolla_ansible": SourceCfg(owner="openstack", branch="stable/2025.2")},
+        base_dirs=(str(tmp_path),),
+    )
+
+
+def test_effective_range_stops_at_target(tmp_path):
+    # The whole point: --target 2025.2 must not drag 2026.1 in, or the 010 back-compat layer emits
+    # compatibility data for the wrong release.
+    assert effective.effective_range(_cfg(tmp_path), "2025.2") == [
+        "2024.1",
+        "2025.1",
+        "2025.2",
+    ]
+
+
+def test_effective_range_rejects_unsupported_target(tmp_path):
+    with pytest.raises(ValueError, match="not a supported release"):
+        effective.effective_range(_cfg(tmp_path), "2027.1")
+
+
+def test_derive_sets_releases_override_and_fresh_caches(tmp_path):
+    base = _cfg(tmp_path)
+    base.ref_cache["poison"] = "must-not-leak"
+    shas = {"2024.1": "1" * 40, "2025.1": "2" * 40, "2025.2": "3" * 40}
+    eff = effective.derive(base, SyncOpts(target="2025.2"), str(tmp_path / "wt"), shas)
+    assert list(eff.releases) == ["2024.1", "2025.1", "2025.2"]
+    # Pinned refs replace the branch for every upstream reader.
+    assert eff.release_refs["kolla_ansible"]["2025.2"] == "3" * 40
+    # Fresh per-run state: a memo from the unpinned config must not survive.
+    assert "poison" not in eff.ref_cache
+    assert eff.groupvars_cache == {}
+
+
+def test_derive_prepends_the_worktree_parent_to_base_dirs(tmp_path):
+    wt = tmp_path / "sync-2025.2" / "defaults"
+    eff = effective.derive(
+        _cfg(tmp_path), SyncOpts(target="2025.2"), str(wt), {"2025.2": "a" * 40}
+    )
+    # _local_repo_dir takes the FIRST base_dir containing <repo>; the worktree
+    # parent must win over a user --base-dir that also holds a defaults checkout.
+    assert eff.base_dirs[0] == str(wt.parent)
+    assert str(tmp_path) in eff.base_dirs[1:]
+
+
+def test_requested_shas_rejects_pin_and_pins_from_together():
+    with pytest.raises(ValueError, match="pass one"):
+        effective.requested_shas(
+            SyncOpts(target="2025.2", pin="a" * 40, pins={"2025.2": "b" * 40}),
+            ["2025.2"],
+            {"2025.2": "c" * 40},
+        )
+
+
+def test_requested_shas_rejects_a_non_sha():
+    with pytest.raises(ValueError, match="40-hex"):
+        effective.requested_shas(
+            SyncOpts(target="2025.2", pin="stable/2025.2"),
+            ["2025.2"],
+            {"2025.2": "c" * 40},
+        )
+
+
+def test_requested_shas_applies_the_pin_only_to_the_target():
+    shas = effective.requested_shas(
+        SyncOpts(target="2025.2", pin="a" * 40),
+        ["2025.1", "2025.2"],
+        {"2025.1": "b" * 40, "2025.2": "c" * 40},
+    )
+    assert shas == {"2025.1": "b" * 40, "2025.2": "a" * 40}
+
+
+def test_check_pin_validates_against_the_real_tip_not_itself(monkeypatch):
+    # Regression: an earlier draft passed a shas map into which the pin had already
+    # been written, making the bound pin <= pin, which merge-base answers 0 for.
+    seen = []
+
+    def fake(repo, anc, desc, cfg):
+        seen.append((anc, desc))
+        return True
+
+    monkeypatch.setattr(effective.source, "is_ancestor", fake)
+    effective.check_pin(None, "2025.2", "p" * 40, "t" * 40, "b" * 40)
+    assert ("p" * 40, "t" * 40) in seen  # pin vs TIP, never pin vs pin
+
+
+def test_check_pin_rejects_a_commit_before_the_branch_point(monkeypatch):
+    def fake(repo, anc, desc, cfg):
+        return not (anc == "b" * 40 and desc == "p" * 40)  # range_base..pin False
+
+    monkeypatch.setattr(effective.source, "is_ancestor", fake)
+    with pytest.raises(effective.source.SourceError, match="before the branch point"):
+        effective.check_pin(None, "2025.2", "p" * 40, "t" * 40, "b" * 40)
+
+
+def test_check_pin_rejects_a_pin_not_reachable_from_the_tip(monkeypatch):
+    monkeypatch.setattr(effective.source, "is_ancestor", lambda repo, a, d, cfg: False)
+    with pytest.raises(effective.source.SourceError, match="not reachable"):
+        effective.check_pin(None, "2025.2", "p" * 40, "t" * 40, "b" * 40)
+
+
+def test_check_pin_is_a_noop_when_nothing_was_overridden(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("must not compare when pin == tip")
+
+    monkeypatch.setattr(effective.source, "is_ancestor", boom)
+    effective.check_pin(None, "2025.2", "t" * 40, "t" * 40, "b" * 40)
+
+
+def test_validate_pins_payload_rejects_a_target_mismatch():
+    with pytest.raises(ValueError, match="produced for target"):
+        effective.validate_pins_payload(
+            {"schema": 1, "target_release": "2026.1", "release_shas": {}},
+            "2025.2",
+            ["2025.2"],
+        )
+
+
+def test_validate_pins_payload_rejects_an_incomplete_release_set():
+    with pytest.raises(ValueError, match="does not match the effective range"):
+        effective.validate_pins_payload(
+            {
+                "schema": 1,
+                "target_release": "2025.2",
+                "release_shas": {"2025.2": "a" * 40},
+                "defaults_base_sha": "d" * 40,
+            },
+            "2025.2",
+            ["2025.1", "2025.2"],
+        )
+
+
+def test_validate_pins_payload_rejects_a_malformed_release_sha():
+    # Validate the whole payload at its boundary rather than relying on a later
+    # call in the intended sequence.
+    with pytest.raises(ValueError, match="not a 40-hex"):
+        effective.validate_pins_payload(
+            {
+                "schema": 1,
+                "target_release": "2025.2",
+                "release_shas": {"2025.1": "a" * 40, "2025.2": "nope"},
+                "defaults_base_sha": "d" * 40,
+            },
+            "2025.2",
+            ["2025.1", "2025.2"],
+        )
+
+
+def test_validate_pins_payload_rejects_a_non_mapping_release_shas():
+    with pytest.raises(ValueError, match="not a mapping"):
+        effective.validate_pins_payload(
+            {"schema": 1, "target_release": "2025.2", "release_shas": ["a"]},
+            "2025.2",
+            ["2025.2"],
+        )
+
+
+def test_validate_pins_payload_rejects_an_unknown_schema():
+    with pytest.raises(ValueError, match="unsupported schema"):
+        effective.validate_pins_payload({"schema": 99}, "2025.2", ["2025.2"])
+
+
+def test_validate_pins_payload_returns_the_map_and_base(tmp_path):
+    shas, base = effective.validate_pins_payload(
+        {
+            "schema": 1,
+            "target_release": "2025.2",
+            "release_shas": {"2025.1": "a" * 40, "2025.2": "b" * 40},
+            "defaults_base_sha": "d" * 40,
+        },
+        "2025.2",
+        ["2025.1", "2025.2"],
+    )
+    assert shas == {"2025.1": "a" * 40, "2025.2": "b" * 40}
+    assert base == "d" * 40
+
+
+def test_resolve_tips_uses_release_to_ref_then_resolve_commit(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        effective.source, "release_to_ref", lambda repo, rel, cfg: f"stable/{rel}"
+    )
+    monkeypatch.setattr(
+        effective.source,
+        "resolve_commit",
+        lambda repo, ref, cfg: ref.replace("stable/", "").replace(".", "") * 8,
+    )
+    tips = effective.resolve_tips(_cfg(tmp_path), ["2025.1", "2025.2"])
+    assert set(tips) == {"2025.1", "2025.2"}
+    assert tips["2025.2"].startswith("20252")

--- a/tests/mirror_sync/test_enablement_additions.py
+++ b/tests/mirror_sync/test_enablement_additions.py
@@ -1,0 +1,19 @@
+from osism_drift import enablement
+
+
+def test_mirror_prefix_is_public_and_matches_the_private_constant():
+    # sync-mirror builds filenames from this; a sibling module must not have to
+    # reach for a private name across a boundary.
+    assert enablement.MIRROR_PREFIX == "001-"
+    assert enablement.MIRROR_PREFIX == enablement._MIRROR_PREFIX
+
+
+def test_upstream_groupvars_files_is_public(monkeypatch):
+    monkeypatch.setattr(
+        enablement,
+        "_upstream_groupvars_named_bodies",
+        lambda rel, cfg: [("nova.yml", b"a: 1\n")],
+    )
+    assert enablement.upstream_groupvars_files("2025.2", None) == [
+        ("nova.yml", b"a: 1\n")
+    ]

--- a/tests/mirror_sync/test_gate.py
+++ b/tests/mirror_sync/test_gate.py
@@ -1,0 +1,207 @@
+import pytest
+from osism_drift.mirror_sync import gate
+from osism_drift.mirror_sync.model import Plan, Row, SyncOpts
+
+# The real idiom, from all/099-kolla.yml:11.
+CANON = "{{ 'yes' if openstack_version in ['2024.1', '2024.2', '2025.1'] else 'no' }}"
+# Real gates the parser must decline, from 099-kolla.yml:103 and :233.
+COMPOUND = (
+    "{{ '8080' if (enable_haproxy | bool and openstack_version not in ['2024.1']) "
+    "else horizon_tls_port }}"
+)
+NESTED = (
+    "{{ (A if ansible_facts.os_family == 'RedHat' else '{}') "
+    "if openstack_version in ['2024.1'] else B }}"
+)
+
+
+def _supply(value):
+    return {"k": {"layers": ["all/099-kolla.yml"], "value": value}}
+
+
+def _plan_with(key, old, new):
+    return Plan(
+        target_release="2025.2",
+        release_shas={},
+        defaults_base_sha="d" * 40,
+        prev_release=None,
+        range_base_sha=None,
+        mirror_writes={},
+        mirror_deletes=(),
+        compat_writes={},
+        compat_deletes=(),
+        changed_writes=(),
+        created_paths=(),
+        rows=(Row(key, old, new, "semantic", (), ""),),
+        added_keys=(),
+        dropped_keys={},
+        added_files=(),
+        deleted_files=(),
+        unowned_compat=(),
+    )
+
+
+def _opts(**kw):
+    return SyncOpts(target="2025.2", **{k: frozenset(v) for k, v in kw.items()})
+
+
+# --- the parser -------------------------------------------------------------
+
+
+def test_parses_the_canonical_shape():
+    g = gate.parse_gate(CANON)
+    assert g == {"old": "yes", "new": "no", "releases": ["2024.1", "2024.2", "2025.1"]}
+
+
+def test_declines_a_compound_condition():
+    assert gate.parse_gate(COMPOUND) is None
+
+
+def test_declines_a_nested_ternary():
+    assert gate.parse_gate(NESTED) is None
+
+
+def test_declines_a_mixed_release_list():
+    """A malformed list must be declined, not crash the run.
+
+    YAML parses ['2024.1', 2024.2] as a str and a float; a later sorted() over the
+    mixture raises TypeError, which escapes as a traceback and exit 1 instead of a
+    controlled refusal pointing at --retain-unverified.
+    """
+    assert (
+        gate.parse_gate("{{ 'a' if openstack_version in ['2024.1', 2024.2] else 'b' }}")
+        is None
+    )
+
+
+def test_declines_an_unquoted_release():
+    assert (
+        gate.parse_gate("{{ 'a' if openstack_version in [2024.1] else 'b' }}") is None
+    )
+
+
+def test_declines_an_empty_release_list():
+    # A gate that retains for no release is meaningless.
+    assert gate.parse_gate("{{ 'a' if openstack_version in [] else 'b' }}") is None
+
+
+def test_accepts_a_trailing_comma():
+    g = gate.parse_gate("{{ 'a' if openstack_version in ['2024.1',] else 'b' }}")
+    assert g["releases"] == ["2024.1"]
+
+
+def test_declines_a_variable_branch():
+    assert (
+        gate.parse_gate("{{ 'a' if openstack_version in ['2024.1'] else b }}") is None
+    )
+
+
+def test_accepts_openstack_release_as_an_alias():
+    g = gate.parse_gate("{{ 'a' if openstack_release in ['2024.1'] else 'b' }}")
+    assert g["releases"] == ["2024.1"]
+
+
+# --- check_retain -----------------------------------------------------------
+
+
+def test_check_retain_accepts_a_correct_gate():
+    note = gate.check_retain(
+        "k", "yes", "no", _supply(CANON), ["2024.1", "2024.2", "2025.1"]
+    )
+    assert "verified" in note
+
+
+def test_check_retain_rejects_a_reversed_gate():
+    """The whole reason association matters.
+
+    A gate returning the NEW value for the older releases and the OLD value for the
+    target names every right release and carries both values, so any set of
+    unordered checks passes it.
+    """
+    reversed_gate = "{{ 'no' if openstack_version in ['2024.1'] else 'yes' }}"
+    with pytest.raises(gate.GateMismatch, match="in-branch"):
+        gate.check_retain("k", "yes", "no", _supply(reversed_gate), ["2024.1"])
+
+
+def test_check_retain_rejects_a_wrong_release_list():
+    with pytest.raises(gate.GateMismatch, match="releases"):
+        gate.check_retain("k", "yes", "no", _supply(CANON), ["2024.1"])
+
+
+def test_check_retain_rejects_a_non_canonical_gate():
+    with pytest.raises(gate.NotCanonical, match="retain-unverified"):
+        gate.check_retain("k", "8080", "x", _supply(COMPOUND), ["2024.1"])
+
+
+def test_check_retain_rejects_a_key_no_later_layer_supplies():
+    with pytest.raises(gate.GateMismatch, match="no later layer"):
+        gate.check_retain("k", "yes", "no", {}, ["2024.1"])
+
+
+def test_check_retain_rejects_a_gate_in_the_010_layer():
+    # 010-* sorts BEFORE 099-*, so it cannot carry retention for a changed value.
+    supply = {"k": {"layers": ["all/010-2025.1.yml"], "value": CANON}}
+    with pytest.raises(gate.GateMismatch, match="no later layer"):
+        gate.check_retain("k", "yes", "no", supply, ["2024.1", "2024.2", "2025.1"])
+
+
+# --- validate_dispositions / missing_dispositions ---------------------------
+
+
+def test_retain_unverified_is_rejected_for_a_canonical_gate():
+    """The strong path must not be bypassable out of habit."""
+    plan = _plan_with("k", "yes", "no")
+    with pytest.raises(gate.WrongDisposition, match="use --retain"):
+        gate.validate_dispositions(
+            plan,
+            _opts(retain_unverified={"k"}),
+            ["2024.1", "2024.2", "2025.1"],
+            _supply(CANON),
+        )
+
+
+def test_retain_unverified_is_rejected_when_no_gate_exists():
+    """Acknowledging nothing is not a disposition."""
+    plan = _plan_with("k", "yes", "no")
+    with pytest.raises(gate.GateMismatch, match="no gate to acknowledge"):
+        gate.validate_dispositions(plan, _opts(retain_unverified={"k"}), ["2024.1"], {})
+
+
+def test_retain_unverified_accepts_a_present_non_canonical_gate():
+    plan = _plan_with("k", "8080", "x")
+    notes = gate.validate_dispositions(
+        plan, _opts(retain_unverified={"k"}), ["2024.1"], _supply(COMPOUND)
+    )
+    assert "acknowledged" in notes["k"]
+
+
+def test_an_unknown_disposition_key_is_an_error():
+    # A stale flag from a previous re-sync would otherwise read as a decision.
+    plan = _plan_with("k", "yes", "no")
+    with pytest.raises(gate.UnknownDisposition, match="typo_key"):
+        gate.validate_dispositions(
+            plan, _opts(accept_upstream={"typo_key"}), ["2024.1"], _supply(CANON)
+        )
+
+
+def test_a_failed_retention_check_propagates_rather_than_becoming_missing():
+    plan = _plan_with("k", "yes", "no")
+    reversed_gate = "{{ 'no' if openstack_version in ['2024.1'] else 'yes' }}"
+    with pytest.raises(gate.GateMismatch):
+        gate.validate_dispositions(
+            plan, _opts(retain={"k"}), ["2024.1"], _supply(reversed_gate)
+        )
+
+
+def test_missing_dispositions_only_lists_rows_with_no_flag():
+    plan = _plan_with("k", "yes", "no")
+    assert gate.missing_dispositions(plan, _opts()) == ["k"]
+    assert gate.missing_dispositions(plan, _opts(retain={"k"})) == []
+
+
+def test_accept_upstream_is_noted():
+    plan = _plan_with("k", "yes", "no")
+    notes = gate.validate_dispositions(
+        plan, _opts(accept_upstream={"k"}), ["2024.1"], _supply(CANON)
+    )
+    assert "upstream" in notes["k"]

--- a/tests/mirror_sync/test_layers.py
+++ b/tests/mirror_sync/test_layers.py
@@ -1,0 +1,449 @@
+import pytest
+from osism_drift.mirror_sync import layers
+
+
+def test_mirror_layer_refuses_a_monolithic_upstream_layout(tmp_path, monkeypatch):
+    # <=2025.1 yields [("all.yml", body)]; writing that makes all/001-all.yml.
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_files",
+        lambda rel, cfg: [("all.yml", b"k: v\n")],
+    )
+    with pytest.raises(layers.MonolithicLayout):
+        layers.mirror_layer(None, "2025.1", tmp_path)
+
+
+def test_mirror_layer_refuses_an_empty_upstream_listing(tmp_path, monkeypatch):
+    # Without this guard the plan is "delete every 001-* file, write nothing":
+    # a renamed upstream path or a bad ref arrives here as an empty list, and
+    # once the writer exists that wipes the whole mirror layer.
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-nova.yml").write_bytes(b"x\n")
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_files", lambda rel, cfg: []
+    )
+    with pytest.raises(layers.EmptyUpstreamLayer, match="listed no group_vars"):
+        layers.mirror_layer(None, "2025.2", tmp_path)
+
+
+def test_every_arms_refusal_shares_one_base(tmp_path):
+    # The CLI catches the base class; a stray sibling would escape as a traceback.
+    for exc in (
+        layers.MonolithicLayout,
+        layers.EmptyUpstreamLayer,
+        layers.UnownedCompatFile,
+    ):
+        assert issubclass(exc, layers.LayerError)
+
+
+def test_mirror_layer_writes_prefixed_copies_and_deletes_orphans(tmp_path, monkeypatch):
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-nova.yml").write_bytes(b"old\n")
+    (allsrc / "001-zun.yml").write_bytes(b"gone upstream\n")
+    (allsrc / "099-kolla.yml").write_bytes(b"osism: yes\n")  # must be untouched
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_files",
+        lambda rel, cfg: [("nova.yml", b"new\n"), ("cinder.yml", b"c\n")],
+    )
+    writes, deletes, added, deleted = layers.mirror_layer(None, "2025.2", tmp_path)
+
+    assert writes == {"all/001-nova.yml": b"new\n", "all/001-cinder.yml": b"c\n"}
+    assert deletes == ("all/001-zun.yml",)
+    assert added == ("all/001-cinder.yml",)
+    assert deleted == ("all/001-zun.yml",)
+
+
+def test_mirror_layer_rejects_an_unsafe_upstream_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_files",
+        lambda rel, cfg: [("sub/nova.yml", b"x\n")],
+    )
+    with pytest.raises(ValueError, match="not a bare basename"):
+        layers.mirror_layer(None, "2025.2", tmp_path)
+
+
+def test_mirror_homes_reads_the_tree_with_last_wins(tmp_path):
+    # Pre-sync homes must come from disk: after an upstream backport on the same
+    # target, the on-disk mirror is an older commit of that target, not prev.
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-common.yml").write_bytes(b"database_address: a\nshared: c\n")
+    (allsrc / "001-database.yml").write_bytes(b"database_address: b\n")
+    homes = layers.mirror_homes(tmp_path)
+    # database.yml sorts after common.yml, so it wins -- as Ansible resolves it.
+    assert homes["database_address"] == "database.yml"
+    assert homes["shared"] == "common.yml"
+
+
+def test_compat_layer_emits_values_from_the_release_that_still_has_them(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        layers.enablement,
+        "dropped_key_release_map",
+        lambda cfg: {"enable_zun": "2025.2", "distro_python_version": "2025.2"},
+    )
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_values",
+        lambda rel, cfg: {"enable_zun": False, "distro_python_version": "3.12"},
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    shas = {"2025.1": "b" * 40, "2025.2": "a" * 40}
+    writes, deletes, dests, _ = layers.compat_layer(
+        None, ["2024.1", "2025.1", "2025.2", "2026.1"], shas, tmp_path
+    )
+    body = writes["all/010-2025.2.yml"]
+    assert "generated-by: sync-mirror" in body
+    # sorted keys, and the complete replay map recorded in the header
+    assert body.index("distro_python_version") < body.index("enable_zun")
+    assert "a" * 40 in body and "b" * 40 in body
+    assert dests == {
+        "enable_zun": "all/010-2025.2.yml",
+        "distro_python_version": "all/010-2025.2.yml",
+    }
+    assert deletes == ()
+
+
+def test_compat_layer_excludes_keys_another_osism_layer_supplies(tmp_path, monkeypatch):
+    """A dropped key OSISM already supplies needs no 010 entry.
+
+    It is redundant -- the enforced union is satisfied -- and shadowed, since
+    010-* sorts before 099-*. Validated against the committed 010 files: without
+    this rule the generator emitted 37 extra keys and all 37 were in
+    osism_supply_excluding_mirror().
+    """
+    monkeypatch.setattr(
+        layers.enablement,
+        "dropped_key_release_map",
+        lambda cfg: {"gone": "2025.1", "enable_redis": "2025.1"},
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: {"enable_redis"}
+    )
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_values",
+        lambda rel, cfg: {"gone": 1, "enable_redis": 2},
+    )
+    _, _, dests, _ = layers.compat_layer(
+        None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path
+    )
+    assert set(dests) == {"gone"}
+
+
+def test_compat_layer_excludes_keys_the_target_still_defines(tmp_path, monkeypatch):
+    """dropped_key_release_map() is not a map of dropped keys.
+
+    It maps every key defined by a release below the newest to the newest such
+    release; a key counts as dropped only when the target no longer defines it.
+    Using the map directly emitted 880 keys for a 2025.2 target where 31 were
+    dropped -- caught by the first end-to-end run, not by a mocked unit test.
+    """
+    monkeypatch.setattr(
+        layers.enablement,
+        "dropped_key_release_map",
+        lambda cfg: {"gone": "2025.1", "still_here": "2025.1"},
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: {"still_here"}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement,
+        "upstream_groupvars_values",
+        lambda rel, cfg: {"gone": 1, "still_here": 2},
+    )
+    writes, _, dests, _ = layers.compat_layer(
+        None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path
+    )
+    assert set(dests) == {"gone"}
+    assert "still_here" not in writes["all/010-2025.1.yml"]
+
+
+def test_compat_layer_raises_when_a_dropped_key_has_no_value(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        layers.enablement, "dropped_key_release_map", lambda cfg: {"ghost": "2025.2"}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_values", lambda rel, cfg: {}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    with pytest.raises(KeyError, match="ghost"):
+        layers.compat_layer(
+            None, ["2025.1", "2025.2", "2026.1"], {"2025.2": "a" * 40}, tmp_path
+        )
+
+
+def _managed(tmp_path, name, marked=True):
+    d = tmp_path / "all"
+    d.mkdir(exist_ok=True)
+    head = "---\n# generated-by: sync-mirror\n" if marked else "---\n# hand written\n"
+    (d / name).write_text(head + "k: 1\n")
+    return tmp_path
+
+
+def test_compat_layer_deletes_a_managed_file_with_no_desired_keys(
+    tmp_path, monkeypatch
+):
+    _managed(tmp_path, "010-2025.1.yml")
+    monkeypatch.setattr(layers.enablement, "dropped_key_release_map", lambda cfg: {})
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_values", lambda rel, cfg: {}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    writes, deletes, _, _ = layers.compat_layer(
+        None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path
+    )
+    assert writes == {}
+    assert deletes == ("all/010-2025.1.yml",)
+
+
+def test_report_mode_reports_an_unmarked_file_instead_of_refusing(
+    tmp_path, monkeypatch
+):
+    """The guard protects writes, so it must not abort a read-only report.
+
+    Blocking there hides the very plan an operator needs in order to discover
+    that a marker commit is required -- which is exactly what happened on the
+    first run against a real defaults tree.
+    """
+    _managed(tmp_path, "010-2025.1.yml", marked=False)
+    monkeypatch.setattr(
+        layers.enablement, "dropped_key_release_map", lambda cfg: {"k": "2025.1"}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_values", lambda rel, cfg: {"k": 1}
+    )
+    writes, _, _, unowned = layers.compat_layer(
+        None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path, strict=False
+    )
+    # The plan is still computed in full, and the blocker is named.
+    assert "all/010-2025.1.yml" in writes
+    assert unowned == ("all/010-2025.1.yml",)
+
+
+def test_compat_layer_refuses_an_unmarked_managed_file(tmp_path, monkeypatch):
+    _managed(tmp_path, "010-2025.1.yml", marked=False)
+    monkeypatch.setattr(
+        layers.enablement, "dropped_key_release_map", lambda cfg: {"k": "2025.1"}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_values", lambda rel, cfg: {"k": 1}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    with pytest.raises(layers.UnownedCompatFile, match="generated-by"):
+        layers.compat_layer(None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path)
+
+
+def test_compat_layer_refuses_to_delete_an_unmarked_file(tmp_path, monkeypatch):
+    _managed(tmp_path, "010-2025.1.yml", marked=False)
+    monkeypatch.setattr(layers.enablement, "dropped_key_release_map", lambda cfg: {})
+    monkeypatch.setattr(layers.enablement, "upstream_groupvars_values", lambda r, c: {})
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    with pytest.raises(layers.UnownedCompatFile):
+        layers.compat_layer(None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path)
+
+
+def test_require_owned_rejects_a_marker_used_inside_a_value(tmp_path, monkeypatch):
+    d = tmp_path / "all"
+    d.mkdir()
+    (d / "010-2025.1.yml").write_text(
+        '---\n# hand written\nnote: "generated-by: sync-mirror"\n'
+    )
+    monkeypatch.setattr(layers.enablement, "dropped_key_release_map", lambda cfg: {})
+    monkeypatch.setattr(layers.enablement, "upstream_groupvars_values", lambda r, c: {})
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    with pytest.raises(layers.UnownedCompatFile):
+        layers.compat_layer(None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path)
+
+
+def test_require_owned_rejects_a_marker_below_the_header(tmp_path, monkeypatch):
+    d = tmp_path / "all"
+    d.mkdir()
+    (d / "010-2025.1.yml").write_text(
+        "---\n" + "# filler\n" * 8 + "# generated-by: sync-mirror\nk: 1\n"
+    )
+    monkeypatch.setattr(layers.enablement, "dropped_key_release_map", lambda cfg: {})
+    monkeypatch.setattr(layers.enablement, "upstream_groupvars_values", lambda r, c: {})
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    with pytest.raises(layers.UnownedCompatFile):
+        layers.compat_layer(None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path)
+
+
+def test_compat_layer_never_inspects_a_file_outside_the_range(tmp_path, monkeypatch):
+    # An unmarked 010 for a release after --target must not even be looked at.
+    _managed(tmp_path, "010-2025.2.yml", marked=False)
+    monkeypatch.setattr(layers.enablement, "dropped_key_release_map", lambda cfg: {})
+    monkeypatch.setattr(layers.enablement, "upstream_groupvars_values", lambda r, c: {})
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    writes, deletes, _, _ = layers.compat_layer(
+        None, ["2025.1", "2025.2"], {"2025.1": "a" * 40}, tmp_path
+    )
+    assert writes == {} and deletes == ()
+
+
+def test_compat_layer_ignores_releases_after_the_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        layers.enablement, "dropped_key_release_map", lambda cfg: {"k": "2025.1"}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_values", lambda rel, cfg: {"k": 1}
+    )
+    monkeypatch.setattr(
+        layers.enablement, "upstream_groupvars_keys", lambda rel, cfg: set()
+    )
+    monkeypatch.setattr(
+        layers.enablement, "osism_supply_excluding", lambda cfg, skip: set()
+    )
+    writes, deletes, _, _ = layers.compat_layer(
+        None, ["2024.1", "2025.1", "2025.2"], {"2025.1": "b" * 40}, tmp_path
+    )
+    assert set(writes) == {"all/010-2025.1.yml"}
+    assert "all/010-2025.2.yml" not in writes
+    assert deletes == ()
+
+
+def test_changed_and_created_compares_bytes_against_disk(tmp_path):
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-nova.yml").write_bytes(b"same\n")
+    writes = {"all/001-nova.yml": b"same\n", "all/001-new.yml": b"fresh\n"}
+    changed, created = layers.changed_and_created(writes, tmp_path)
+    assert changed == ("all/001-new.yml",)
+    assert created == ("all/001-new.yml",)
+
+
+def test_changed_and_created_sees_a_content_change(tmp_path):
+    allsrc = tmp_path / "all"
+    allsrc.mkdir()
+    (allsrc / "001-nova.yml").write_bytes(b"old\n")
+    changed, created = layers.changed_and_created(
+        {"all/001-nova.yml": b"new\n"}, tmp_path
+    )
+    assert changed == ("all/001-nova.yml",)
+    assert created == ()
+
+
+def test_generated_sequences_are_indented_for_yamllint():
+    """osism/defaults runs yamllint with `extends: default`, so a block sequence
+    at the parent's indentation is an error -- a re-sync would fail CI on a file
+    this generator wrote. yaml.safe_dump produces exactly that form."""
+    out = layers._render_compat(
+        "2025.1",
+        ["run_default_subdirectories"],
+        {"run_default_subdirectories": ["/run/netns", "/run/nova"]},
+        {"2025.1": "a" * 40},
+    )
+    assert 'run_default_subdirectories:\n  - "/run/netns"\n  - "/run/nova"\n' in out
+    assert '\n- "/run/netns"' not in out
+
+
+def test_generated_values_match_the_upstream_quoting_style():
+    """The 001 mirror carries 677 double-quoted values and no single-quoted ones,
+    and the hand-written 010 layers matched it. PyYAML's default inverts that and
+    escapes an embedded quote as '' where upstream writes '."""
+    out = layers._render_compat(
+        "2025.2",
+        ["jinja", "falsey", "count", "empty"],
+        {
+            "jinja": "{{ x == 'influxdb' }}",
+            "falsey": "no",
+            "count": 42463,
+            "empty": None,
+        },
+        {"2025.2": "a" * 40},
+    )
+    assert "jinja: \"{{ x == 'influxdb' }}\"" in out
+    assert "''" not in out
+    assert 'falsey: "no"' in out
+    # non-strings keep their type and stay unquoted
+    assert "count: 42463" in out
+    assert "empty: null" in out
+
+
+def test_mapping_keys_are_not_quoted():
+    """Upstream writes a bare key with a quoted value; quoting both would be a
+    style the directory does not use anywhere."""
+    out = layers._render_compat(
+        "2025.2", ["some_key"], {"some_key": "v"}, {"2025.2": "a" * 40}
+    )
+    assert 'some_key: "v"' in out
+    assert '"some_key"' not in out
+
+
+def test_nested_keys_stay_bare_and_keep_upstream_order():
+    """Upstream writes nested keys bare too, and sorting every level reordered a
+    container's ulimits to hard-before-soft for no gain."""
+    out = layers._render_compat(
+        "2025.2",
+        ["z_last", "a_first", "dims"],
+        {
+            "z_last": "v",
+            "a_first": "v",
+            "dims": {"ulimits": {"nofile": {"soft": 1048576, "hard": 1048576}}},
+        },
+        {"2025.2": "a" * 40},
+    )
+    assert "  ulimits:\n    nofile:\n      soft: 1048576\n      hard: 1048576" in out
+    assert '"ulimits"' not in out
+    # the top level is still sorted, which is what determinism needs
+    assert out.index("a_first:") < out.index("dims:") < out.index("z_last:")

--- a/tests/mirror_sync/test_model.py
+++ b/tests/mirror_sync/test_model.py
@@ -1,0 +1,63 @@
+from osism_drift.mirror_sync.model import Plan, Row
+
+
+def _plan(**kw):
+    base = dict(
+        target_release="2025.2",
+        release_shas={"2025.2": "a" * 40},
+        defaults_base_sha="d" * 40,
+        prev_release="2025.1",
+        range_base_sha="b" * 40,
+        mirror_writes={"all/001-nova.yml": b"x\n"},
+        mirror_deletes=(),
+        compat_writes={},
+        compat_deletes=(),
+        unowned_compat=(),
+        changed_writes=(),
+        created_paths=(),
+        rows=(),
+        added_keys=(),
+        dropped_keys={},
+        added_files=(),
+        deleted_files=(),
+    )
+    base.update(kw)
+    return Plan(**base)
+
+
+def test_has_changes_is_false_when_every_write_is_unchanged():
+    # mirror_writes is the DESIRED layer and always non-empty; only
+    # changed_writes may drive has_changes, or exit 0 is unreachable.
+    assert _plan().has_changes is False
+
+
+def test_has_changes_true_on_a_changed_write():
+    assert _plan(changed_writes=("all/001-nova.yml",)).has_changes is True
+
+
+def test_has_changes_true_on_a_mirror_delete_alone():
+    assert _plan(mirror_deletes=("all/001-zun.yml",)).has_changes is True
+
+
+def test_has_changes_true_on_a_compat_delete_alone():
+    assert _plan(compat_deletes=("all/010-2025.1.yml",)).has_changes is True
+
+
+def test_semantic_keys_selects_only_semantic_rows_in_row_order():
+    rows = (
+        Row("b", "no", False, "representation", (), ""),
+        Row("a", 1, 2, "semantic", (), ""),
+        Row("c", 1, 1, "notation", (), ""),
+        Row("z", 3, 4, "semantic", (), ""),
+    )
+    assert _plan(rows=rows).semantic_keys == ("a", "z")
+
+
+def test_plan_is_frozen():
+    import dataclasses
+
+    import pytest
+
+    p = _plan()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.target_release = "2026.1"

--- a/tests/mirror_sync/test_render.py
+++ b/tests/mirror_sync/test_render.py
@@ -1,0 +1,157 @@
+import json
+
+from osism_drift.mirror_sync import render
+from osism_drift.mirror_sync.model import Plan, Row, SyncOpts
+
+
+def _plan(**kw):
+    base = dict(
+        target_release="2026.1",
+        release_shas={"2025.2": "a" * 40, "2026.1": "b" * 40},
+        defaults_base_sha="d" * 40,
+        prev_release="2025.2",
+        range_base_sha="c" * 40,
+        mirror_writes={"all/001-nova.yml": b"x\n"},
+        mirror_deletes=("all/001-zun.yml",),
+        compat_writes={"all/010-2025.2.yml": "---\n"},
+        compat_deletes=(),
+        unowned_compat=(),
+        changed_writes=("all/001-nova.yml",),
+        created_paths=(),
+        rows=(
+            Row(
+                "kolla_base_distro_version_default_map",
+                "bookworm",
+                "trixie",
+                "semantic",
+                ("536f4ae1a Add support for Debian Trixie (13)",),
+                "",
+            ),
+            Row("notify_transport_url", "{% if a %}", "{%if a %}", "notation", (), ""),
+            Row("enable_x", "no", False, "representation", (), "not proven inert"),
+            Row(
+                "openstack_release",
+                "2025.2",
+                "2026.1",
+                "overridden",
+                (),
+                "supplied unconditionally by versions.yml",
+            ),
+        ),
+        added_keys=("_ssl_modern_options",),
+        dropped_keys={"enable_zun": "all/010-2025.2.yml"},
+        added_files=("all/001-valkey.yml",),
+        deleted_files=("all/001-zun.yml",),
+    )
+    base.update(kw)
+    return Plan(**base)
+
+
+def test_json_payload_is_deterministic_and_versioned():
+    p = render.json_payload(_plan())
+    assert p["schema"] == 1
+    assert p["has_changes"] is True
+    assert p["missing_dispositions"] == ["kolla_base_distro_version_default_map"]
+    assert p["applied"] is None
+    # No wall-clock anywhere, so two runs diff cleanly.
+    assert "timestamp" not in json.dumps(p)
+    # Pins round-trip for --pins-from, which validates these three fields.
+    assert p["target_release"] == "2026.1"
+    assert p["release_shas"]["2026.1"] == "b" * 40
+    assert p["defaults_base_sha"] == "d" * 40
+
+
+def test_json_payload_round_trips_through_the_pins_validator():
+    from osism_drift.mirror_sync import effective
+
+    payload = json.loads(json.dumps(render.json_payload(_plan())))
+    shas, base = effective.validate_pins_payload(
+        payload, "2026.1", ["2025.2", "2026.1"]
+    )
+    assert shas == {"2025.2": "a" * 40, "2026.1": "b" * 40}
+    assert base == "d" * 40
+
+
+def test_json_counts_each_class_separately():
+    counts = render.json_payload(_plan())["counts"]
+    assert counts == {
+        "semantic": 1,
+        "notation": 1,
+        "representation": 1,
+        "overridden": 1,
+    }
+
+
+def test_text_labels_representation_and_shows_attribution():
+    out = render.text(_plan())
+    assert "not proven inert" in out
+    assert "536f4ae1a" in out  # attribution shown for semantic rows
+    assert "all/010-2025.2.yml" in out  # dropped-key destination
+    assert "all/001-valkey.yml" in out  # added file
+
+
+def test_text_offers_only_the_dispositions_this_build_supports():
+    out = render.text(_plan())
+    assert "--accept-upstream" in out
+    # --retain / --retain-unverified arrive with --apply; argparse rejects
+    # them here, so pointing at them would send the operator to a dead option.
+    assert "--retain" not in out
+
+
+def test_text_distinguishes_no_rows_from_nothing_computed():
+    empty = _plan(rows=(), changed_writes=(), mirror_deletes=(), compat_deletes=())
+    out = render.text(empty)
+    assert "no value differences" in out
+
+
+def test_exit_code_2_when_a_blocker_exists_even_with_no_semantic_row():
+    # An unowned 010 file stops --apply, so reporting 1 ("would apply cleanly")
+    # would be false.
+    p = _plan(rows=(), unowned_compat=("all/010-2025.1.yml",))
+    assert render.exit_code(p, SyncOpts(target="2026.1")) == 2
+    assert render.json_payload(p)["blocked"] == [
+        "all/010-2025.1.yml lacks the generator marker"
+    ]
+
+
+def test_text_names_the_blocker_and_how_to_clear_it():
+    out = render.text(_plan(unowned_compat=("all/010-2025.1.yml",)))
+    assert "--apply is blocked" in out
+    assert "generated-by: sync-mirror" in out
+
+
+def test_exit_code_2_when_a_semantic_row_is_undispositioned():
+    assert render.exit_code(_plan(), SyncOpts(target="2026.1")) == 2
+
+
+def test_exit_code_1_when_changes_are_planned_and_all_dispositioned():
+    opts = SyncOpts(
+        target="2026.1",
+        accept_upstream=frozenset({"kolla_base_distro_version_default_map"}),
+    )
+    assert render.exit_code(_plan(), opts) == 1
+
+
+def test_exit_code_0_when_nothing_would_change():
+    empty = _plan(rows=(), changed_writes=(), mirror_deletes=(), compat_deletes=())
+    assert render.exit_code(empty, SyncOpts(target="2026.1")) == 0
+
+
+def test_exit_code_1_when_only_files_change_and_no_row_needs_review():
+    # A clean round: files added or dropped, nothing semantic. Neither "nothing to
+    # do" nor "needs review" -- this is the case a single-axis status cannot state.
+    p = _plan(rows=(), changed_writes=("all/001-new.yml",))
+    assert render.exit_code(p, SyncOpts(target="2026.1")) == 1
+    assert render.json_payload(p)["has_changes"] is True
+
+
+def test_retain_flags_do_not_clear_a_missing_disposition():
+    # They exist on SyncOpts for --apply, but the gate parser that gives them
+    # meaning is not in this build; honouring them would report "all dispositioned"
+    # without performing the checks they promise.
+    opts = SyncOpts(
+        target="2026.1",
+        retain=frozenset({"kolla_base_distro_version_default_map"}),
+        retain_unverified=frozenset({"kolla_base_distro_version_default_map"}),
+    )
+    assert render.exit_code(_plan(), opts) == 2

--- a/tests/mirror_sync/test_render.py
+++ b/tests/mirror_sync/test_render.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from osism_drift.mirror_sync import render
 from osism_drift.mirror_sync.model import Plan, Row, SyncOpts
@@ -90,12 +91,18 @@ def test_text_labels_representation_and_shows_attribution():
     assert "all/001-valkey.yml" in out  # added file
 
 
-def test_text_offers_only_the_dispositions_this_build_supports():
+def test_text_offers_every_disposition_now_that_the_gate_exists():
     out = render.text(_plan())
-    assert "--accept-upstream" in out
-    # --retain / --retain-unverified arrive with --apply; argparse rejects
-    # them here, so pointing at them would send the operator to a dead option.
-    assert "--retain" not in out
+    for flag in ("--accept-upstream", "--retain", "--retain-unverified"):
+        assert flag in out
+
+
+def test_text_lists_the_dispositions_that_were_applied():
+    # validate_dispositions() computes these labels; a report that dropped them
+    # would leave the operator unable to tell verified from merely acknowledged.
+    out = render.text(_plan(), notes={"k": "verified against the canonical gate"})
+    assert "dispositioned:" in out
+    assert "k: verified against the canonical gate" in out
 
 
 def test_text_distinguishes_no_rows_from_nothing_computed():
@@ -138,20 +145,246 @@ def test_exit_code_0_when_nothing_would_change():
 
 
 def test_exit_code_1_when_only_files_change_and_no_row_needs_review():
-    # A clean round: files added or dropped, nothing semantic. Neither "nothing to
-    # do" nor "needs review" -- this is the case a single-axis status cannot state.
+    # A clean re-sync: files added or dropped, nothing semantic. Neither
+    # "nothing to do" nor "needs review" -- the case a single-axis status
+    # cannot state.
     p = _plan(rows=(), changed_writes=("all/001-new.yml",))
     assert render.exit_code(p, SyncOpts(target="2026.1")) == 1
     assert render.json_payload(p)["has_changes"] is True
 
 
-def test_retain_flags_do_not_clear_a_missing_disposition():
-    # They exist on SyncOpts for --apply, but the gate parser that gives them
-    # meaning is not in this build; honouring them would report "all dispositioned"
-    # without performing the checks they promise.
+def test_a_retain_flag_clears_a_row_now_that_it_is_validated_elsewhere():
+    """render no longer second-guesses the flags.
+
+    gate.validate_dispositions() raises on a bad --retain before a report is ever
+    rendered, so a flag present at this point is sound. Re-checking here would
+    duplicate the logic and lose the diagnostic that makes the check useful.
+    """
     opts = SyncOpts(
         target="2026.1",
         retain=frozenset({"kolla_base_distro_version_default_map"}),
-        retain_unverified=frozenset({"kolla_base_distro_version_default_map"}),
     )
-    assert render.exit_code(_plan(), opts) == 2
+    assert render.exit_code(_plan(), opts) == 1
+
+
+def test_acceptance_command_prepends_the_worktree_and_keeps_every_base_dir():
+    wt = "/repos/osism/defaults.worktrees/sync-2025.2/defaults"
+    cmd = render.acceptance_command(wt, ["/repos/osism", "/repos/openstack"])
+    dirs = re.findall(r"--base-dir (\S+)", cmd)
+    # The worktree parent must come FIRST: _local_repo_dir takes the first
+    # --base-dir containing <repo>, so with the operator's checkout ahead of it the
+    # detector measures the unsynced tree and looks like a pass on nothing.
+    assert dirs[0] == "/repos/osism/defaults.worktrees/sync-2025.2"
+    # Every configured root must survive -- dropping /repos/openstack loses
+    # kolla-ansible, so the printed command cannot reproduce the check at all.
+    assert dirs[1:] == ["/repos/osism", "/repos/openstack"]
+    assert "--group all" in cmd
+    # Any --base-dir puts check-drift in local mode and the worktree parent holds
+    # only `defaults`; without this a repo absent from every root is a hard error.
+    assert "--remote-fallback" in cmd
+
+
+def test_acceptance_command_works_for_a_remote_mode_run():
+    cmd = render.acceptance_command("/wt/sync-2025.2/defaults", [])
+    assert re.findall(r"--base-dir (\S+)", cmd) == ["/wt/sync-2025.2"]
+    assert "--remote-fallback" in cmd
+
+
+def test_acceptance_command_quotes_paths_with_spaces():
+    cmd = render.acceptance_command(
+        "/repos/my defaults.worktrees/sync-2025.2/defaults", ["/repos/os ism"]
+    )
+    # Copy-pasted into a shell, an unquoted path with a space silently means
+    # something else.
+    assert "'/repos/my defaults.worktrees/sync-2025.2'" in cmd
+    assert "'/repos/os ism'" in cmd
+
+
+def test_acceptance_command_warns_when_the_derived_range_is_newer():
+    """The printed command is not the gate when a newer release is declared.
+
+    check-drift derives its range from latest/openstack-*.yml and has no flag
+    to narrow it, so with 2026.1 declared it measures that release -- and a
+    large count would otherwise read as a failure of a 2025.2 sync. Observed
+    live: 230 to act on immediately after a clean apply.
+    """
+    cmd = render.acceptance_command(
+        "/wt/sync-2025.2/defaults", [], target="2025.2", newest="2026.1"
+    )
+    assert "NOTE" in cmd and "2026.1" in cmd
+    assert "releases:" in cmd
+
+
+def test_acceptance_command_has_no_caveat_when_the_target_is_newest():
+    cmd = render.acceptance_command(
+        "/wt/sync-2026.1/defaults", [], target="2026.1", newest="2026.1"
+    )
+    assert "NOTE" not in cmd
+
+
+def test_text_summary_names_each_class_and_what_it_means():
+    """A bare "semantic (16)" does not tell a reader whether it needs them."""
+    out = render.text(_plan())
+    assert "4 mirror values changed. 1 need" in out
+    assert "blocks --apply" in out
+    assert "truth value did not" in out
+    assert "an unconditional OSISM layer already supplies the key" in out
+
+
+def test_text_inlines_a_short_value_but_elides_a_long_one():
+    """The values worth reading are the ones a terminal renders worst."""
+    long_new = "{{\n" + "  x or\n" * 40 + "}}"
+    out = render.text(
+        _plan(
+            rows=(
+                Row("short_key", "influxdb", "sqlalchemy", "semantic", (), ""),
+                Row("long_key", "{{ x }}", long_new, "semantic", (), ""),
+            )
+        )
+    )
+    assert "short_key: 'influxdb' -> 'sqlalchemy'" in out
+    assert "long_key: str, 7 chars -> multi-line str," in out
+    assert "(see report)" in out
+    assert "x or" not in out  # the body never reaches the terminal
+
+
+def test_text_truncates_a_long_name_list_to_a_sample_and_a_count():
+    keys = [f"enable_{i:03d}" for i in range(101)]
+    out = render.text(
+        _plan(rows=tuple(Row(k, "no", False, "representation", (), "n") for k in keys))
+    )
+    assert "and 89 more (see report)" in out
+    assert "mores" not in out
+    assert "enable_100" not in out  # past the cap
+
+
+def test_text_groups_a_repeated_note_instead_of_repeating_it():
+    """classify() emits a constant note per class; printing it 101 times is noise."""
+    rows = tuple(
+        Row(f"enable_{i}", "no", False, "representation", (), "not proven inert")
+        for i in range(8)
+    )
+    out = render.text(_plan(rows=rows))
+    assert out.count("not proven inert") == 1
+
+
+def test_text_header_names_the_base_ref_alongside_its_sha():
+    out = render.text(_plan(), SyncOpts(target="2026.1", base_ref="my-branch"))
+    assert f"target        2026.1 @ {'b' * 40}" in out
+    assert f"defaults base my-branch @ {'d' * 40}" in out
+
+
+def test_text_states_the_exit_code_and_where_the_full_values_are():
+    out = render.text(_plan(), code=2, report_path="/tmp/sync-mirror-2026.1.txt")
+    assert "exit 2: operator action needed; the plan was not applied" in out
+    assert "full values for every key: /tmp/sync-mirror-2026.1.txt" in out
+
+
+def test_text_omits_the_exit_line_when_the_caller_has_no_code_yet():
+    assert "exit " not in render.text(_plan())
+
+
+def test_shape_pluralises_a_single_entry_correctly():
+    """A value too big to inline is described by shape; "1 keys" reads as a bug."""
+    big = {f"k{i}": "v" * 20 for i in range(9)}
+    out = render.text(
+        _plan(
+            rows=(Row("k", big, {"only": "v" * 80}, "semantic", (), ""),),
+            dropped_keys={"enable_zun": "all/010-2025.2.yml"},
+        )
+    )
+    assert "dict, 9 keys -> dict, 1 key (see report)" in out
+    assert "all/010-2025.2.yml: 1 key" in out
+    assert "1 keys" not in out
+
+
+def test_a_back_compat_layer_says_whether_it_is_new_or_already_correct():
+    """Counts alone read as "75 keys move now"; most rounds move none of them."""
+    out = render.text(
+        _plan(
+            dropped_keys={"a": "all/010-2024.2.yml", "b": "all/010-2025.2.yml"},
+            created_paths=("all/010-2025.2.yml",),
+            changed_writes=("all/010-2025.2.yml",),
+        )
+    )
+    assert "all/010-2024.2.yml: 1 key (unchanged)" in out
+    assert "all/010-2025.2.yml: 1 key (new file)" in out
+    assert "not all of them new" in out
+
+
+def test_a_header_only_rewrite_says_so_instead_of_just_rewritten():
+    """A 010 header carries the pinned commits, so the bytes move every run.
+
+    Reporting that as "rewritten" reads as data loss on a file losing no key.
+    """
+    out = render.text(
+        _plan(
+            dropped_keys={"a": "all/010-2024.2.yml"},
+            changed_writes=("all/010-2024.2.yml",),
+            created_paths=(),
+            compat_effects={
+                "all/010-2024.2.yml": {"added": [], "removed": [], "updated": []}
+            },
+        )
+    )
+    assert "only the pin header is refreshed" in out
+    assert "rewritten" not in out
+
+
+def test_real_key_movement_is_reported_as_counts():
+    out = render.text(
+        _plan(
+            dropped_keys={"a": "all/010-2024.2.yml"},
+            changed_writes=("all/010-2024.2.yml",),
+            created_paths=(),
+            compat_effects={
+                "all/010-2024.2.yml": {
+                    "added": ["x", "y"],
+                    "removed": ["z"],
+                    "updated": ["w"],
+                }
+            },
+        )
+    )
+    assert "(+2 keys, -1 key, 1 value updated)" in out
+
+
+def test_exit_0_after_an_apply_does_not_claim_there_was_nothing_to_do():
+    """Exit 0 covers both "nothing to do" and "applied"; they are not the same."""
+    applied = render.text(_plan(), code=0, applied=True)
+    idle = render.text(_plan(), code=0, applied=None)
+    assert "exit 0: the plan was applied to the worktree" in applied
+    assert "already matches" not in applied
+    assert "exit 0: nothing to do; the mirror already matches" in idle
+
+
+def test_commit_summary_records_pins_and_dispositions():
+    """The 010 headers carry the pins, but nothing in the tree records which
+    disposition a key got -- accepting upstream leaves no trace at all."""
+    out = render.commit_summary(
+        _plan(),
+        SyncOpts(
+            target="2026.1",
+            accept_upstream=frozenset({"key_a", "key_b"}),
+            retain=frozenset({"key_c"}),
+        ),
+    )
+    assert "Generated by sync-mirror for 2026.1." in out
+    assert f"  2026.1: {'b' * 40}" in out
+    assert f"osism/defaults base: {'d' * 40}" in out
+    assert "accepted upstream (2):" in out
+    assert "key_a, key_b" in out
+    assert "retained, gate verified (1):" in out
+    assert "key_c" in out
+    # a flag nobody used must not appear as an empty heading
+    assert "NOT verified" not in out
+
+
+def test_commit_summary_wraps_at_72_for_a_commit_body():
+    keys = {f"a_rather_long_variable_name_{i:02d}" for i in range(20)}
+    out = render.commit_summary(
+        _plan(), SyncOpts(target="2026.1", accept_upstream=frozenset(keys))
+    )
+    assert max(len(line) for line in out.split("\n")) <= 72
+    for k in keys:
+        assert k in out

--- a/tests/mirror_sync/test_source_commits.py
+++ b/tests/mirror_sync/test_source_commits.py
@@ -1,0 +1,174 @@
+import subprocess
+
+import pytest
+import responses
+from osism_drift import source
+from osism_drift.config import Config, Remote, SourceCfg
+
+
+def _git(d, *args):
+    subprocess.run(["git", "-C", str(d), *args], check=True, capture_output=True)
+
+
+def _rev(d, ref="HEAD"):
+    return subprocess.run(
+        ["git", "-C", str(d), "rev-parse", ref], capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _upstream_clone(tmp_path):
+    """A real git repo standing in for kolla-ansible, with two commits."""
+    d = tmp_path / "kolla-ansible"
+    d.mkdir()
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    (d / "a.txt").write_text("one\n")
+    _git(d, "add", "a.txt")
+    _git(d, "commit", "-qm", "first")
+    first = _rev(d)
+    (d / "a.txt").write_text("two\n")
+    _git(d, "add", "a.txt")
+    _git(d, "commit", "-qm", "second")
+    second = _rev(d)
+    _git(d, "branch", "stable/2025.2", second)
+    return d, first, second
+
+
+def _cfg(tmp_path=None):
+    return Config(
+        remote=Remote("https://raw/", "https://api/", "main", "osism"),
+        release_version="latest",
+        plugins={},
+        sources={"kolla_ansible": SourceCfg(owner="openstack", branch="stable/2025.2")},
+        base_dirs=(str(tmp_path),) if tmp_path else (),
+    )
+
+
+def test_resolve_commit_local_peels_branch_to_sha(tmp_path):
+    _, _, second = _upstream_clone(tmp_path)
+    got = source.resolve_commit("kolla_ansible", "stable/2025.2", _cfg(tmp_path))
+    assert got == second
+    assert len(got) == 40
+
+
+def test_resolve_commit_local_accepts_a_sha(tmp_path):
+    _, first, _ = _upstream_clone(tmp_path)
+    assert source.resolve_commit("kolla_ansible", first, _cfg(tmp_path)) == first
+
+
+def test_resolve_commit_prefers_a_remote_over_a_stale_local_branch(tmp_path):
+    """A stale local branch of the same name must not win.
+
+    Observed in a real checkout: refs/heads/stable/2025.2 sat five commits behind
+    refs/remotes/origin/stable/2025.2, and sync-mirror consequently proposed
+    reverting an upstream fix that had landed in between.
+    """
+    d, first, second = _upstream_clone(tmp_path)
+    # A remote-tracking ref at the newer commit, a local head at the older one.
+    _git(d, "update-ref", "refs/remotes/origin/stable/2025.2", second)
+    _git(d, "branch", "-f", "stable/2025.2", first)
+    got = source.resolve_commit("kolla_ansible", "stable/2025.2", _cfg(tmp_path))
+    assert got == second, "resolved the stale local head instead of the remote"
+
+
+def test_resolve_commit_falls_back_to_a_local_head(tmp_path):
+    # With no remote carrying the ref, a local head is the only answer available.
+    d, first, _ = _upstream_clone(tmp_path)
+    _git(d, "branch", "-f", "local-only", first)
+    assert source.resolve_commit("kolla_ansible", "local-only", _cfg(tmp_path)) == first
+
+
+def test_resolve_commit_unknown_ref_raises(tmp_path):
+    _upstream_clone(tmp_path)
+    with pytest.raises(source.SourceError, match="cannot resolve"):
+        source.resolve_commit("kolla_ansible", "stable/nope", _cfg(tmp_path))
+
+
+def test_is_ancestor_local(tmp_path):
+    _, first, second = _upstream_clone(tmp_path)
+    cfg = _cfg(tmp_path)
+    assert source.is_ancestor("kolla_ansible", first, second, cfg) is True
+    assert source.is_ancestor("kolla_ansible", second, first, cfg) is False
+
+
+def test_is_ancestor_raises_on_a_missing_descendant(tmp_path):
+    # git exits 128 here, not 1. Mapping every non-zero to False would report
+    # "not an ancestor" for what is really an operational failure.
+    _, first, _ = _upstream_clone(tmp_path)
+    with pytest.raises(source.SourceError, match="not present"):
+        source.is_ancestor("kolla_ansible", first, "0" * 40, _cfg(tmp_path))
+
+
+def test_is_ancestor_raises_when_the_ancestor_object_is_absent(tmp_path):
+    _, _, second = _upstream_clone(tmp_path)
+    with pytest.raises(source.SourceError, match="not present"):
+        source.is_ancestor("kolla_ansible", "0" * 40, second, _cfg(tmp_path))
+
+
+def test_merge_base_local(tmp_path):
+    d, first, second = _upstream_clone(tmp_path)
+    _git(d, "checkout", "-q", "-b", "side", first)
+    (d / "b.txt").write_text("side\n")
+    _git(d, "add", "b.txt")
+    _git(d, "commit", "-qm", "side")
+    side = _rev(d)
+    assert source.merge_base("kolla_ansible", second, side, _cfg(tmp_path)) == first
+
+
+def test_local_checkout_returns_none_when_remote():
+    assert source.local_checkout("kolla_ansible", _cfg()) is None
+
+
+def test_local_checkout_returns_the_dir_when_local(tmp_path):
+    d, _, _ = _upstream_clone(tmp_path)
+    assert source.local_checkout("kolla_ansible", _cfg(tmp_path)) == d
+
+
+@responses.activate
+def test_resolve_commit_remote_reads_sha_from_commits_api():
+    responses.add(
+        responses.GET,
+        "https://api/openstack/kolla-ansible/commits/stable/2025.2",
+        json={"sha": "a" * 40},
+        status=200,
+    )
+    assert source.resolve_commit("kolla_ansible", "stable/2025.2", _cfg()) == "a" * 40
+
+
+@responses.activate
+def test_resolve_commit_rejects_a_non_sha_from_the_api():
+    # resolve_commit documents a 40-hex return; callers pin refs from it, so an
+    # abbreviated or malformed id must not escape its own boundary.
+    responses.add(
+        responses.GET,
+        "https://api/openstack/kolla-ansible/commits/stable/2025.2",
+        json={"sha": "abc123"},
+        status=200,
+    )
+    with pytest.raises(source.SourceError, match="not a 40-hex commit"):
+        source.resolve_commit("kolla_ansible", "stable/2025.2", _cfg())
+
+
+@responses.activate
+def test_is_ancestor_remote_uses_compare_status():
+    base, head = "b" * 40, "c" * 40
+    responses.add(
+        responses.GET,
+        f"https://api/openstack/kolla-ansible/compare/{base}...{head}",
+        json={"status": "ahead"},
+        status=200,
+    )
+    assert source.is_ancestor("kolla_ansible", base, head, _cfg()) is True
+
+
+@responses.activate
+def test_merge_base_remote_reads_compare_payload():
+    a, b = "1" * 40, "2" * 40
+    responses.add(
+        responses.GET,
+        f"https://api/openstack/kolla-ansible/compare/{a}...{b}",
+        json={"status": "diverged", "merge_base_commit": {"sha": "3" * 40}},
+        status=200,
+    )
+    assert source.merge_base("kolla_ansible", a, b, _cfg()) == "3" * 40

--- a/tests/mirror_sync/test_worktree.py
+++ b/tests/mirror_sync/test_worktree.py
@@ -1,0 +1,140 @@
+import subprocess
+
+import pytest
+from osism_drift.mirror_sync import worktree
+
+
+def _git(d, *a):
+    subprocess.run(["git", "-C", str(d), *a], check=True, capture_output=True)
+
+
+def _defaults_repo(tmp_path):
+    d = tmp_path / "defaults"
+    (d / "all").mkdir(parents=True)
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    (d / "all" / "099-kolla.yml").write_text("osism: true\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    return d
+
+
+def test_default_path_leaf_is_named_defaults(tmp_path):
+    got = worktree.default_path(tmp_path / "defaults", "2025.2")
+    # The leaf MUST be "defaults": source._local_repo_dir resolves <base-dir>/<repo>,
+    # so check-drift cannot address the synced tree otherwise.
+    assert got.name == "defaults"
+    assert got.parent.name == "sync-2025.2"
+
+
+def test_create_yields_a_clean_tree_and_the_base_commit(tmp_path):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    sha = worktree.create(d, wt, "main")
+    assert len(sha) == 40
+    assert (wt / "all" / "099-kolla.yml").exists()
+    assert (
+        subprocess.run(
+            ["git", "-C", str(wt), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        == ""
+    )
+    worktree.remove(d, wt)
+
+
+def test_create_refuses_an_existing_path(tmp_path):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    wt.mkdir(parents=True)
+    with pytest.raises(worktree.WorktreeExists, match="already exists"):
+        worktree.create(d, wt, "main")
+
+
+def test_uncommitted_operator_work_is_not_consulted(tmp_path):
+    d = _defaults_repo(tmp_path)
+    (d / "all" / "099-kolla.yml").write_text("osism: LOCAL EDIT\n")
+    wt = worktree.default_path(d, "2025.2")
+    worktree.create(d, wt, "main")
+    # The worktree comes from --base-ref, so the dirty checkout is invisible.
+    assert "LOCAL EDIT" not in (wt / "all" / "099-kolla.yml").read_text()
+    worktree.remove(d, wt)
+
+
+def test_create_removes_the_worktree_when_head_cannot_be_read(tmp_path, monkeypatch):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    real = worktree._git
+
+    def fake(repo, *args):
+        if args[:1] == ("rev-parse",):
+
+            class R:
+                returncode = 1
+                stdout = b""
+                stderr = b""
+
+            return R()
+        return real(repo, *args)
+
+    monkeypatch.setattr(worktree, "_git", fake)
+    with pytest.raises(worktree.CreateFailed, match="HEAD did not resolve"):
+        worktree.create(d, wt, "main")
+    assert not wt.exists()
+
+
+def test_session_removes_on_exit_by_default(tmp_path):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    with worktree.session(d, wt, "main") as (path, sha):
+        assert path.exists() and len(sha) == 40
+    assert not wt.exists()
+
+
+def test_session_removes_on_exception_too(tmp_path):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    with pytest.raises(RuntimeError):
+        with worktree.session(d, wt, "main"):
+            raise RuntimeError("boom")
+    assert not wt.exists()
+
+
+def test_session_keeps_when_asked(tmp_path):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    with worktree.session(d, wt, "main", keep=True) as (path, _):
+        assert path.exists()
+    assert wt.exists()
+    worktree.remove(d, wt)
+
+
+def test_session_raises_when_cleanup_fails(tmp_path, monkeypatch):
+    # A silently failed cleanup leaves the default path occupied, so the NEXT run
+    # refuses with a confusing "already exists" instead of the real cause.
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    monkeypatch.setattr(worktree, "remove", lambda *a: False)
+    with pytest.raises(worktree.CleanupFailed, match="could not be removed"):
+        with worktree.session(d, wt, "main"):
+            pass
+
+
+def test_cleanup_failure_does_not_mask_the_original_error(tmp_path, monkeypatch):
+    d = _defaults_repo(tmp_path)
+    wt = worktree.default_path(d, "2025.2")
+    monkeypatch.setattr(worktree, "remove", lambda *a: False)
+    with pytest.raises(worktree.CleanupFailed) as ei:
+        with worktree.session(d, wt, "main"):
+            raise RuntimeError("original")
+    assert isinstance(ei.value.__cause__, RuntimeError)
+    assert str(ei.value.__cause__) == "original"
+
+
+def test_every_failure_is_a_worktree_error(tmp_path):
+    # The CLI catches the base class; a stray sibling exception would escape as
+    # exit 1 with a traceback instead of the documented operational status.
+    for exc in (worktree.WorktreeExists, worktree.CreateFailed, worktree.CleanupFailed):
+        assert issubclass(exc, worktree.WorktreeError)

--- a/tests/mirror_sync/test_write.py
+++ b/tests/mirror_sync/test_write.py
@@ -1,0 +1,168 @@
+import pytest
+from osism_drift.mirror_sync import write
+from osism_drift.mirror_sync.model import Plan
+
+
+def _plan(tree, **kw):
+    base = dict(
+        target_release="2025.2",
+        release_shas={"2025.2": "a" * 40},
+        defaults_base_sha="d" * 40,
+        prev_release=None,
+        range_base_sha=None,
+        mirror_writes={"all/001-nova.yml": b"new\n", "all/001-same.yml": b"same\n"},
+        mirror_deletes=("all/001-zun.yml",),
+        compat_writes={"all/010-2025.1.yml": "---\nk: 1\n"},
+        compat_deletes=(),
+        changed_writes=("all/001-nova.yml", "all/010-2025.1.yml"),
+        created_paths=("all/010-2025.1.yml",),
+        rows=(),
+        added_keys=(),
+        dropped_keys={},
+        added_files=(),
+        deleted_files=(),
+        unowned_compat=(),
+    )
+    base.update(kw)
+    return Plan(**base)
+
+
+def _tree(tmp_path):
+    d = tmp_path / "all"
+    d.mkdir()
+    (d / "001-nova.yml").write_bytes(b"old\n")
+    (d / "001-same.yml").write_bytes(b"same\n")
+    (d / "001-zun.yml").write_bytes(b"gone\n")
+    return tmp_path
+
+
+def test_writes_only_changed_paths(tmp_path):
+    t = _tree(tmp_path)
+    before = (t / "all" / "001-same.yml").stat().st_mtime_ns
+    result = write.apply_plan(_plan(t), t)
+    assert (t / "all" / "001-nova.yml").read_bytes() == b"new\n"
+    assert (t / "all" / "010-2025.1.yml").read_text() == "---\nk: 1\n"
+    # An unchanged file is not rewritten: it would dirty git diff and mtimes for
+    # 55 of 56 files in a typical re-sync.
+    assert (t / "all" / "001-same.yml").stat().st_mtime_ns == before
+    assert result["written"] == ["all/001-nova.yml", "all/010-2025.1.yml"]
+
+
+def test_deletes_after_writing(tmp_path):
+    t = _tree(tmp_path)
+    result = write.apply_plan(_plan(t), t)
+    assert not (t / "all" / "001-zun.yml").exists()
+    assert result["deleted"] == ["all/001-zun.yml"]
+
+
+def test_a_missing_delete_target_is_not_an_error(tmp_path):
+    t = _tree(tmp_path)
+    (t / "all" / "001-zun.yml").unlink()
+    assert write.apply_plan(_plan(t), t)["deleted"] == []
+
+
+def test_refuses_a_path_outside_the_all_directory(tmp_path):
+    t = _tree(tmp_path)
+    p = _plan(
+        t, mirror_writes={"../escape.yml": b"x\n"}, changed_writes=("../escape.yml",)
+    )
+    with pytest.raises(write.WriteFailed, match="not a plain relative path"):
+        write.apply_plan(p, t)
+    assert not (tmp_path.parent / "escape.yml").exists()
+
+
+def test_refuses_when_the_all_directory_is_a_symlink(tmp_path):
+    """A confinement root derived from the path being checked is not a check.
+
+    With `all` a symlink to an external directory, resolving both sides put them
+    in that directory and the comparison passed -- measured before the fix, the
+    accepted path was outside the worktree entirely.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    tree = tmp_path / "wt"
+    tree.mkdir()
+    (tree / "all").symlink_to(outside)
+    with pytest.raises(write.WriteFailed, match="symlink"):
+        write._resolve(tree, "all/001-nova.yml")
+
+
+def test_refuses_a_symlinked_destination(tmp_path):
+    # Writing through a link mutates its target rather than the planned path.
+    t = _tree(tmp_path)
+    target = tmp_path / "elsewhere.yml"
+    target.write_bytes(b"target\n")
+    (t / "all" / "001-link.yml").symlink_to(target)
+    with pytest.raises(write.WriteFailed, match="symlink"):
+        write._resolve(t, "all/001-link.yml")
+    assert target.read_bytes() == b"target\n"
+
+
+def test_refuses_a_symlinked_delete_target(tmp_path):
+    t = _tree(tmp_path)
+    target = tmp_path / "keep-me.yml"
+    target.write_bytes(b"keep\n")
+    (t / "all" / "001-link.yml").symlink_to(target)
+    p = _plan(t, mirror_deletes=("all/001-link.yml",))
+    with pytest.raises(write.WriteFailed, match="symlink"):
+        write.apply_plan(p, t)
+    assert target.exists()
+
+
+def test_refuses_a_traversal_that_stays_lexically_under_all(tmp_path):
+    # "all/../../escape.yml" starts with "all/" lexically, so a prefix test alone
+    # accepts it.
+    t = _tree(tmp_path)
+    with pytest.raises(write.WriteFailed, match="not a plain relative path"):
+        write._resolve(t, "all/../../escape.yml")
+
+
+def test_refuses_an_absolute_path(tmp_path):
+    t = _tree(tmp_path)
+    with pytest.raises(write.WriteFailed, match="not a plain relative path"):
+        write._resolve(t, "/etc/passwd")
+
+
+def test_refuses_when_the_plan_is_blocked(tmp_path):
+    t = _tree(tmp_path)
+    p = _plan(t, unowned_compat=("all/010-2025.1.yml",))
+    with pytest.raises(write.WriteFailed, match="blocked"):
+        write.apply_plan(p, t)
+    # Nothing was written, so the caller may remove the worktree.
+    assert (t / "all" / "001-nova.yml").read_bytes() == b"old\n"
+
+
+def test_signals_before_the_first_mutation(tmp_path):
+    """The callback must fire before anything is touched, and only then.
+
+    The caller keys the worktree's survival on it: a failure before the first
+    write means nothing was modified, while a failure after it leaves partial
+    state that must be preserved for inspection.
+    """
+    t = _tree(tmp_path)
+    seen = []
+
+    def note():
+        # Nothing may have changed on disk yet when this fires.
+        seen.append((t / "all" / "001-nova.yml").read_bytes())
+
+    write.apply_plan(_plan(t), t, on_first_write=note)
+    assert seen == [b"old\n"]
+
+
+def test_a_preflight_failure_does_not_signal(tmp_path):
+    t = _tree(tmp_path)
+    p = _plan(t, changed_writes=("all/001-has-no-content.yml",))
+    calls = []
+    with pytest.raises(write.WriteFailed, match="no desired content"):
+        write.apply_plan(p, t, on_first_write=lambda: calls.append(1))
+    assert calls == [], "nothing was written, so the tree may be removed"
+
+
+def test_a_blocked_plan_does_not_signal(tmp_path):
+    t = _tree(tmp_path)
+    p = _plan(t, unowned_compat=("all/010-2025.1.yml",))
+    calls = []
+    with pytest.raises(write.WriteFailed):
+        write.apply_plan(p, t, on_first_write=lambda: calls.append(1))
+    assert calls == []

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,11 @@ setenv =
     PYTHONPATH = {toxinidir}/src
 commands =
     python3 src/check-drift.py {posargs:--group all}
+
+[testenv:sync-mirror]
+basepython = python3
+deps = -r requirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}/src
+commands =
+    python3 src/sync-mirror.py {posargs}


### PR DESCRIPTION
Adds `tox -e sync-mirror`, which computes the per-release re-sync of the kolla mirror layer in [osism/defaults](https://github.com/osism/defaults) as one plan, and stops at every point where the right answer is a judgement call rather than a derivation. It replaces a hand-written job of roughly fifteen commits per release.

## What it does

`osism/defaults` carries upstream kolla-ansible's `ansible/group_vars/all` as layers under `all/`, loaded in lexical order: `001-<service>.yml` is a byte-for-byte copy of upstream's file of that name, `010-<release>.yml` carries keys an older supported release still defines after the newest one stopped defining them, and `099-kolla.yml` holds OSISM's own opinions.

Automated: the `001` byte copy including file additions and deletions, key-level `010-<release>.yml` emission, commit pinning for every release in range, classification of each changed value, and the upstream commit behind each semantic one.

Left to the operator, on purpose: every semantic decision. `--apply` refuses while any semantic change lacks an explicit `--accept-upstream`, `--retain` or `--retain-unverified`. `--retain` does not write the `099` gate that expresses retention — it verifies the gate you wrote, including that the right branch carries the right value. Also out of scope: `099` edits, `002-images-*`, pushing and opening PRs.

    tox -e sync-mirror -- --target 2026.1 \
        --defaults-dir ~/src/osism/defaults \
        --base-dir ~/src/osism --base-dir ~/src/openstack

Nothing is written without `--apply`, which writes into a throwaway worktree rather than your checkout. `--commit` then branches that worktree and commits, on request. Exit codes: 0 nothing to do or applied, 1 changes ready to apply, 2 operator action needed, 3 refused.

## Docs

`docs/sync-mirror.md` is the reference; `docs/sync-mirror-tutorial.md` walks one complete re-sync, and every command and block of output in it comes from a real run.

## Testing

628 tests, green at every commit individually, and hermetic — verified behind a dead proxy, which is how three tests making live GitHub calls were found. flake8, black and yamllint are clean whole-tree.

Validated against hand-made ground truth: the generated `010-{2024.1,2024.2,2025.1}.yml` reproduce osism/defaults#296 and osism/defaults#297 key for key and value for value, and the `001` layer needs no change against the merged per-service layout — the tool and that work agree independently.

## Part of a cross-repo effort

The effort, the two `osism/defaults` changes that go with this, and the argument for the order they should merge in are all in one place:

- osism/issues#1439

The short version for reviewing *this* PR: it is worth exercising against a `main` that already has osism/defaults#302 merged, because that is the tree every future operator will run against.

## Prerequisites, both merged

- osism/release#2679
- osism/defaults#300


