### PR TITLE
Add role_registry_orphan: flag docker_registry_* role defaults nothing uses

### DIFF
--- a/docs/check-drift-image.md
+++ b/docs/check-drift-image.md
@@ -220,18 +220,17 @@ is host/OS setup with no container images, so it is intentionally not scanned.
 Each source is read via
 `source.list_tree(repo, root, config)`, which recursively enumerates every
 file in a single call — a working-tree walk for a local checkout (these
-consumer repos are unpinned), one `git/trees?recursive=1` GitHub API call for
-remote. Only `.yml`, `.yaml`, and `.j2` files are then read: a
-`{{ <alias>_image }}` reference lives only in ansible YAML or a jinja template,
-so every other file is skipped without a read — which in remote mode avoids one
-HTTP request each. The files that are read are decoded with `errors="ignore"`
-so a non-UTF-8 blob is skipped without error.
+consumer repos are unpinned) or for the extracted archive of a remote one,
+and one `git/trees?recursive=1` GitHub API call only under `--use-raw-get`.
+Only `.yml`, `.yaml`, and `.j2` files are then read: a `{{ <alias>_image }}`
+reference lives only in ansible YAML or a jinja template, so every other file
+is skipped without a read. The files that are read are decoded with
+`errors="ignore"` so a non-UTF-8 blob is skipped without error.
 
-**`--base-dir` vs remote**: with a local checkout enumeration and reads are
-cheap (a filesystem walk plus local file reads). A remote read fetches the tree
-index first and then issues one HTTP request per scanned `.yml`/`.yaml`/`.j2`
-file, which is significantly slower for a large collection. Pass `--base-dir`
-with the local checkout when iterating on this check.
+**Cost**: cheap in every default mode — a filesystem walk plus local file
+reads, whether the tree came from `--base-dir` or from a fetched archive (see
+[Archive backend](check-drift-kolla.md#archive-backend)). Only `--use-raw-get` makes this scan
+expensive, turning each of the ~500 scanned files into its own HTTP request.
 
 **A missing consumer root is a hard error**: an absent
 `ansible-collection-services/roles/` or `ansible-playbooks-manager/playbooks/`
@@ -332,6 +331,10 @@ under each base dir.
 A repo not found under any `--base-dir` is a **hard error** (all missing
 repos are listed at once). Pass `--remote-fallback` to fetch not-found repos
 remotely instead. To fetch everything from GitHub, just omit `--base-dir`.
+
+Remote repos are fetched as one tarball per `(repo, ref)` and read locally
+from the extracted tree, not one HTTP request per file — see the kolla doc's
+[Archive backend](check-drift-kolla.md#archive-backend).
 
 ## Output
 

--- a/docs/check-drift-image.md
+++ b/docs/check-drift-image.md
@@ -246,6 +246,64 @@ deploys them), so skipping on that criterion would mask the signal.
 **Inputs**: generics manager template, and the `.yml`/`.yaml`/`.j2` files under
 ansible-collection-services/roles/ and ansible-playbooks-manager/playbooks/.
 
+### `role_registry_orphan`
+
+Reports `docker_registry_<alias>` variables **defined** in a role's
+`defaults/main.yml` that **nothing references** — no role, no manager
+playbook, and not the generics manager render template.
+
+This closes the gap `image_orphan` cannot reach. `image_orphan` starts from
+the aliases the manager template *emits*; once an obsolete emit is deleted,
+the role-default remnants that pointed at it leave that plugin's field of
+view entirely. `docker_registry_osism_netbox` is the worked example: the
+`osism_netbox` emit was removed from generics, and with it the only handle
+`image_orphan` had on the leftover registry override. The two plugins meet
+in the middle — `image_orphan` walks forward from the render, this one walks
+backward from the role default.
+
+An orphaned `docker_registry_<alias>` is not merely untidy: it is an
+operator-facing knob that silently does nothing. Someone setting it is
+overriding the registry for an image the collection no longer resolves.
+
+#### Definitions and consumer scan
+
+Definitions are the top-level `docker_registry_<alias>:` keys in each
+`ansible-collection-services/roles/<role>/defaults/main.yml`. Bare
+`docker_registry` is the base override, outside the per-image family, and is
+not scanned.
+
+A variable counts as consumed when its name appears anywhere in a
+`.yml`/`.yaml`/`.j2` file under `ansible-collection-services/roles/`,
+`ansible-playbooks-manager/playbooks/`, or
+`generics/environments/manager/` — **outside its own definition line**. A
+definition still consumes the vars in its *value*, so
+`docker_registry_x: "{{ docker_registry_ansible }}"` defines `x` and
+references `ansible` in one line.
+
+Two details the match deliberately gets right:
+
+- **Bare names count, not just `{{ ... }}`.** `docker_registry_mirrors` is
+  consumed as a loop source in `roles/docker/templates/daemon.json.j2`
+  (`{% for mirror in docker_registry_mirrors %}`). A `{{ var }}`-only
+  pattern would report it as dead.
+- **A longer name does not mask its prefix.** `_` is a word character, so
+  the `\b`-anchored match keeps `docker_registry_osism` from being counted
+  as referenced by an occurrence of `docker_registry_osism_frontend`.
+
+The generics manager template is scanned as a consumer because it renders
+`docker_registry_<alias>` into every deployed `images.yml` — a variable used
+only there is genuinely consumed.
+
+Any occurrence of the name outside a definition counts, comments included.
+That is deliberately conservative: for a checker whose finding is "delete
+this line", a false orphan is the costlier error.
+
+**Inputs**: `ansible-collection-services/roles/*/defaults/main.yml` for
+definitions, and the `.yml`/`.yaml`/`.j2` files under
+`ansible-collection-services/roles/`,
+`ansible-playbooks-manager/playbooks/` and
+`generics/environments/manager/` for consumers.
+
 ### Stream-resolved tags
 
 Some `<alias>_tag` lines in the generics manager template resolve at deploy

--- a/docs/check-drift-image.md
+++ b/docs/check-drift-image.md
@@ -222,15 +222,19 @@ Each source is read via
 file in a single call — a working-tree walk for a local checkout (these
 consumer repos are unpinned) or for the extracted archive of a remote one,
 and one `git/trees?recursive=1` GitHub API call only under `--use-raw-get`.
-Only `.yml`, `.yaml`, and `.j2` files are then read: a `{{ <alias>_image }}`
-reference lives only in ansible YAML or a jinja template, so every other file
-is skipped without a read. The files that are read are decoded with
-`errors="ignore"` so a non-UTF-8 blob is skipped without error.
+**Every file is read — no extension filter.** A `{{ <alias>_image }}`
+reference usually lives in ansible YAML or a jinja template, but nothing
+guarantees it: a shell script under `files/` or an extension-less template can
+carry one too. Skipping those would make a deployed image look unconsumed, and
+this plugin's remediation is to delete the image definition — so the scan reads
+everything and lets non-matching content simply not match. Files are decoded
+with `errors="ignore"`, so a binary blob is inert rather than an error.
 
 **Cost**: cheap in every default mode — a filesystem walk plus local file
 reads, whether the tree came from `--base-dir` or from a fetched archive (see
-[Archive backend](check-drift-kolla.md#archive-backend)). Only `--use-raw-get` makes this scan
-expensive, turning each of the ~500 scanned files into its own HTTP request.
+[Archive backend](check-drift-kolla.md#archive-backend)). The scanned trees are
+under 600 files and under a megabyte in total. Only `--use-raw-get` makes this
+scan expensive, turning each file into its own HTTP request.
 
 **A missing consumer root is a hard error**: an absent
 `ansible-collection-services/roles/` or `ansible-playbooks-manager/playbooks/`
@@ -242,7 +246,7 @@ No stream-resolved skip is applied: aliases like `osism_netbox` are
 themselves stream-resolved yet can still be genuine orphans (nothing
 deploys them), so skipping on that criterion would mask the signal.
 
-**Inputs**: generics manager template, and the `.yml`/`.yaml`/`.j2` files under
+**Inputs**: generics manager template, and every file under
 ansible-collection-services/roles/ and ansible-playbooks-manager/playbooks/.
 
 ### `role_registry_orphan`
@@ -271,10 +275,13 @@ Definitions are the top-level `docker_registry_<alias>:` keys in each
 `docker_registry` is the base override, outside the per-image family, and is
 not scanned.
 
-A variable counts as consumed when its name appears anywhere in a
-`.yml`/`.yaml`/`.j2` file under `ansible-collection-services/roles/`,
+A variable counts as consumed when its name appears anywhere in any file
+under `ansible-collection-services/roles/`,
 `ansible-playbooks-manager/playbooks/`, or
-`generics/environments/manager/` — **outside its own definition line**. A
+`generics/environments/manager/` — **outside its own definition line**. As in
+`image_orphan`, no extension filter is applied: a reference in a shell script
+under `files/` counts, and missing it would report a live registry override
+for deletion. A
 definition still consumes the vars in its *value*, so
 `docker_registry_x: "{{ docker_registry_ansible }}"` defines `x` and
 references `ansible` in one line.
@@ -298,7 +305,7 @@ That is deliberately conservative: for a checker whose finding is "delete
 this line", a false orphan is the costlier error.
 
 **Inputs**: `ansible-collection-services/roles/*/defaults/main.yml` for
-definitions, and the `.yml`/`.yaml`/`.j2` files under
+definitions, and every file under
 `ansible-collection-services/roles/`,
 `ansible-playbooks-manager/playbooks/` and
 `generics/environments/manager/` for consumers.

--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -57,6 +57,29 @@ pinned repo whose `--base-dir` dir is not a git clone falls back to remote (with
 `--remote-fallback`) or is a hard error. With no local clone they are read
 remotely at their refs.
 
+### Archive backend
+
+Remote repos are **not** read one file at a time. For each `(repo, ref)` the
+tool downloads a single tarball
+(`{github_api}/{owner}/{repo}/tarball/{ref}`), extracts it to a temporary
+directory, and serves every subsequent `read`, `read_optional` and `list_tree`
+from that extracted tree as an ordinary local file access. The temp directory
+is removed at exit.
+
+The extracted path is memoized on `config.snapshot_cache`, and the driver
+builds **one** `config` and passes it to every plugin in the run. So a repo is
+fetched once per run no matter how many plugins read it, and no matter how many
+files each one reads. A plugin that walks a whole role tree — several hundred
+`.yml`/`.yaml`/`.j2` files — therefore costs no additional requests once any
+earlier plugin has caused that repo to be fetched, which is what lets several
+plugins scan the same tree cheaply in one run.
+
+`--use-raw-get` opts out, fetching each file with its own raw GET and each
+tree with its own API call. It is a fallback for when the archive backend
+misbehaves, and it is much slower: dozens of requests over several minutes,
+and far more than that for a plugin that scans a whole role tree. The
+periodic `release-tox-drift` job does not pass it.
+
 ### Per-repo source overrides (`sources:`)
 
 By default every repo is read from `default_owner` (osism) at `remote.branch`. A

--- a/src/drift-config.yml
+++ b/src/drift-config.yml
@@ -21,6 +21,7 @@ plugins:
   role_unpinned: {enabled: true}
   rolling_pin: {enabled: true}
   image_orphan: {enabled: true}
+  role_registry_orphan: {enabled: true}
   kolla_version_chain_inner: {enabled: true}
   kolla_version_chain_upstream: {enabled: true}
   kolla_inventory: {enabled: true}

--- a/src/osism_drift/drift/__init__.py
+++ b/src/osism_drift/drift/__init__.py
@@ -15,6 +15,7 @@ from osism_drift.drift import (
     kolla_version_chain_inner,
     kolla_version_chain_upstream,
     release_vs_manager,
+    role_registry_orphan,
     role_shadows,
     role_unpinned,
     rolling_pin,
@@ -40,6 +41,7 @@ IMAGE_PLUGINS = [
     role_unpinned,
     rolling_pin,
     image_orphan,
+    role_registry_orphan,
 ]
 
 PLUGIN_GROUPS = {"image": IMAGE_PLUGINS, "kolla": KOLLA_PLUGINS}

--- a/src/osism_drift/drift/image_orphan.py
+++ b/src/osism_drift/drift/image_orphan.py
@@ -37,12 +37,6 @@ _CONSUMER_SOURCES = [
     ("ansible_playbooks_manager", "playbooks"),
 ]
 
-# A {{ <alias>_image }} reference only ever lives in ansible YAML or a jinja
-# template; restricting the scan to these extensions avoids one remote read per
-# non-text file (LICENSE, .md, binaries) in the recursively-listed role/playbook
-# trees, which in remote mode is one HTTP GET each.
-_CONSUMER_EXTS = (".yml", ".yaml", ".j2")
-
 _TAG_RE = re.compile(r"^(\w+)_tag:", re.M)
 _IMAGE_REF_RE = re.compile(r"\{\{\s*(\w+)_image\s*\}\}")
 
@@ -55,8 +49,9 @@ def run(config, allowlist, verbose: bool = False) -> list:
     consumed = set()
     for repo, root in _CONSUMER_SOURCES:
         for path in source.list_tree(repo, root, config):
-            if not path.endswith(_CONSUMER_EXTS):
-                continue
+            # Every file, no extension filter: a consumer in a shell script or
+            # an extension-less template would otherwise read as an orphan, and
+            # this plugin's remediation is to delete the image definition.
             body = source.read_optional(repo, path, config)
             if body is None:
                 continue

--- a/src/osism_drift/drift/role_registry_orphan.py
+++ b/src/osism_drift/drift/role_registry_orphan.py
@@ -1,0 +1,117 @@
+"""role_registry_orphan plugin: docker_registry_<alias> defaults nothing uses."""
+
+import re
+
+from osism_drift import source
+from osism_drift.model import DriftEntry
+
+NAME = "role_registry_orphan"
+DESCRIPTION = (
+    "Flag docker_registry_<alias> variables defined in a role's defaults that "
+    "no role, manager playbook or manager render template references "
+    "(orphaned registry overrides)."
+)
+INPUT_FILES = [
+    ("ansible_collection_services", "roles/*/defaults/main.yml"),
+    ("ansible_collection_services", "roles/ (docker_registry_<alias> consumers)"),
+    ("ansible_playbooks_manager", "playbooks/ (docker_registry_<alias> consumers)"),
+    ("generics", "environments/manager/ (docker_registry_<alias> consumers)"),
+]
+SUMMARY = (
+    "{n} docker_registry_<alias> role defaults that nothing references "
+    "(orphaned registry overrides):"
+)
+REMEDIATION = (
+    "remove the orphaned docker_registry_<alias> line — an operator setting it "
+    "is overriding a registry for an image the collection no longer resolves. "
+    "Allowlist it only if it is consumed in a form this scan misses; the scan "
+    "counts any occurrence of the name outside its own definition line."
+)
+
+_ROLES_REPO = "ansible_collection_services"
+
+# Where a docker_registry_<alias> reference can legitimately live. Roles and
+# manager playbooks deploy the containers; the generics manager template renders
+# the var into every deployed images.yml, so a var used only there is consumed.
+_CONSUMER_SOURCES = [
+    ("ansible_collection_services", "roles"),
+    ("ansible_playbooks_manager", "playbooks"),
+    ("generics", "environments/manager"),
+]
+_CONSUMER_EXTS = (".yml", ".yaml", ".j2")
+
+# Bare \b match, not {{ ... }}: docker_registry_mirrors is consumed as a loop
+# source ({% for m in docker_registry_mirrors %}) and would false-flag under a
+# {{ var }}-only pattern. "_" is a word character, so \b also keeps
+# docker_registry_osism from matching inside docker_registry_osism_frontend.
+_REF_RE = re.compile(r"\bdocker_registry_[a-z0-9_]+\b")
+_DEF_RE = re.compile(r"^(docker_registry_[a-z0-9_]+)\s*:")
+
+
+def _definitions(text: str) -> list[str]:
+    """Return the docker_registry_<alias> keys defined at the top level."""
+    return [m.group(1) for line in text.splitlines() if (m := _DEF_RE.match(line))]
+
+
+def _references(text: str) -> set[str]:
+    """Return every docker_registry_<alias> named outside its own definition.
+
+    A definition line still consumes the vars in its *value*: the real
+    `docker_registry_osism_netbox: "{{ docker_registry_ansible }}"` defines one
+    var and references another.
+    """
+    out = set()
+    for line in text.splitlines():
+        names = _REF_RE.findall(line)
+        defined = _DEF_RE.match(line)
+        if defined and names and names[0] == defined.group(1):
+            names = names[1:]
+        out.update(names)
+    return out
+
+
+def run(config, allowlist, verbose: bool = False) -> list:
+    defined = []
+    for role in sorted(source.list_dir(_ROLES_REPO, "roles", config, dirs_only=True)):
+        rel = f"roles/{role}/defaults/main.yml"
+        body = source.read_optional(_ROLES_REPO, rel, config)
+        if body is None:
+            continue
+        text = body.decode("utf-8", errors="ignore")
+        for var in _definitions(text):
+            defined.append((var, f"ansible-collection-services/{rel}"))
+
+    consumed = set()
+    for repo, root in _CONSUMER_SOURCES:
+        for path in source.list_tree(repo, root, config):
+            if not path.endswith(_CONSUMER_EXTS):
+                continue
+            body = source.read_optional(repo, path, config)
+            if body is None:
+                continue
+            consumed |= _references(body.decode("utf-8", errors="ignore"))
+
+    drifts = []
+    for var, found_src in sorted(set(defined)):
+        if var in consumed:
+            continue
+        d = DriftEntry(
+            plugin=NAME,
+            image=var,
+            alias=var[len("docker_registry_") :],
+            expected=(
+                f"a reference to {var} in a role, a manager playbook "
+                "or the manager render template"
+            ),
+            found=f"defined in {found_src}; nothing references it",
+            expected_src=(
+                "ansible-collection-services/roles/, "
+                "ansible-playbooks-manager/playbooks/, "
+                "generics/environments/manager/"
+            ),
+            found_src=found_src,
+            summary=SUMMARY,
+            remediation=REMEDIATION,
+        )
+        drifts.append(allowlist.apply(d))
+    return drifts

--- a/src/osism_drift/drift/role_registry_orphan.py
+++ b/src/osism_drift/drift/role_registry_orphan.py
@@ -38,7 +38,6 @@ _CONSUMER_SOURCES = [
     ("ansible_playbooks_manager", "playbooks"),
     ("generics", "environments/manager"),
 ]
-_CONSUMER_EXTS = (".yml", ".yaml", ".j2")
 
 # Bare \b match, not {{ ... }}: docker_registry_mirrors is consumed as a loop
 # source ({% for m in docker_registry_mirrors %}) and would false-flag under a
@@ -84,8 +83,8 @@ def run(config, allowlist, verbose: bool = False) -> list:
     consumed = set()
     for repo, root in _CONSUMER_SOURCES:
         for path in source.list_tree(repo, root, config):
-            if not path.endswith(_CONSUMER_EXTS):
-                continue
+            # Every file, no extension filter: see image_orphan. A missed
+            # consumer here reports a live registry override for deletion.
             body = source.read_optional(repo, path, config)
             if body is None:
                 continue

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/adminer/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/adminer/defaults/main.yml
@@ -1,3 +1,5 @@
 adminer_tag: '4.7'
 adminer_namespace: library
 adminer_image: "{{ adminer_image }}"
+docker_registry_adminer: registry.example
+adminer_registry_url: "{{ docker_registry_adminer }}/adminer"

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/docker/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/docker/defaults/main.yml
@@ -1,0 +1,1 @@
+docker_registry_loopy: []

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/docker/templates/daemon.json.j2
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/docker/templates/daemon.json.j2
@@ -1,0 +1,3 @@
+{
+  "registry-mirrors": [{% for mirror in docker_registry_loopy %}"{{ mirror }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+}

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/manager/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/manager/defaults/main.yml
@@ -1,3 +1,9 @@
 ara_server_mariadb_tag: '11.8.3'
 manager_redis_tag: '7.4.6-alpine'
 ara_server_tag: "{{ lookup('vars', 'ara_server_tag', default=Undefined) }}"
+docker_registry: registry.example/dockerhub
+docker_registry_ansible: registry.example
+docker_registry_osism: "{{ docker_registry_ansible }}"
+docker_registry_osism_frontend: "{{ docker_registry_ansible }}"
+docker_registry_pb: "{{ docker_registry_ansible }}"
+docker_registry_gen: "{{ docker_registry_ansible }}"

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/netbox/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/netbox/defaults/main.yml
@@ -1,1 +1,2 @@
 netbox_redis_tag: '7.4.6-alpine'
+osism_frontend_registry: "{{ docker_registry_osism_frontend }}"

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/shellcons/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/shellcons/defaults/main.yml
@@ -1,0 +1,1 @@
+docker_registry_shellcons: registry.example

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/shellcons/files/entrypoint.sh
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/shellcons/files/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Both plugins must see this file: it is the only consumer of the shellcons
+# alias and of docker_registry_shellcons, and it is not .yml/.yaml/.j2.
+exec docker run --rm "{{ shellcons_image }}" --registry "{{ docker_registry_shellcons }}"

--- a/tests/image_drift/fixtures/ansible-collection-services/roles/widget/defaults/main.yml
+++ b/tests/image_drift/fixtures/ansible-collection-services/roles/widget/defaults/main.yml
@@ -1,1 +1,2 @@
 widget_tag: '2.0'
+docker_registry_widget: "{{ docker_registry_ansible }}"

--- a/tests/image_drift/fixtures/ansible-playbooks-manager/playbooks/pull.yml
+++ b/tests/image_drift/fixtures/ansible-playbooks-manager/playbooks/pull.yml
@@ -9,3 +9,6 @@
       community.docker.docker_image:
         name: "{{ pbonly_image }}"
         source: pull
+    - name: Log in to the pull registry
+      community.docker.docker_login:
+        registry_url: "{{ docker_registry_pb }}"

--- a/tests/image_drift/fixtures/generics/environments/manager/images.yml
+++ b/tests/image_drift/fixtures/generics/environments/manager/images.yml
@@ -16,3 +16,4 @@ ceph_ansible_tag: "{{ versions['ceph_ansible'] }}"
 ceph_ansible_tag: "{{ '{{' }} ceph_version|default(manager_version) {{ '}}' }}"
 {% endif -%}
 gen_image: "{{ '{{' }} docker_registry_gen|default('registry.example') {{ '}}' }}/gen:1"
+shellcons_tag: "{{ versions['shellcons'] }}"

--- a/tests/image_drift/fixtures/generics/environments/manager/images.yml
+++ b/tests/image_drift/fixtures/generics/environments/manager/images.yml
@@ -15,3 +15,4 @@ ceph_ansible_tag: "{{ versions['ceph_ansible'] }}"
 {% else -%}
 ceph_ansible_tag: "{{ '{{' }} ceph_version|default(manager_version) {{ '}}' }}"
 {% endif -%}
+gen_image: "{{ '{{' }} docker_registry_gen|default('registry.example') {{ '}}' }}/gen:1"

--- a/tests/image_drift/test_image_orphan.py
+++ b/tests/image_drift/test_image_orphan.py
@@ -43,20 +43,14 @@ def test_playbook_consumed_alias_not_detected(cfg):
     assert "pbonly" not in drifts
 
 
-def test_non_text_files_are_not_read(cfg, monkeypatch):
-    """Only .yml/.yaml/.j2 files can hold a {{ x_image }} ref; every other file
-    in the listed trees must be skipped (one remote GET each in remote mode)."""
-    read_paths = []
-    real = image_orphan.source.read_optional
-
-    def spy(repo, path, config):
-        read_paths.append(path)
-        return real(repo, path, config)
-
-    monkeypatch.setattr(image_orphan.source, "read_optional", spy)
-    image_orphan.run(cfg, Allowlist(()))
-    assert read_paths, "expected some consumer files to be read"
-    assert all(p.endswith((".yml", ".yaml", ".j2")) for p in read_paths)
+def test_consumer_in_an_unfiltered_file_is_found(cfg):
+    """shellcons is emitted and its only {{ shellcons_image }} consumer lives
+    in roles/shellcons/files/entrypoint.sh — not a .yml/.yaml/.j2 file. The
+    scan must read it. Skipping such files to save reads would report a
+    deployed image as an orphan, and this plugin's remediation is to delete
+    the image definition."""
+    drifts = _by_alias(image_orphan.run(cfg, Allowlist(())))
+    assert "shellcons" not in drifts
 
 
 def test_allowlist_suppresses_orphan(cfg):

--- a/tests/image_drift/test_plugin_registry.py
+++ b/tests/image_drift/test_plugin_registry.py
@@ -15,6 +15,7 @@ def test_image_plugins_registered():
     assert "role_unpinned" in names
     assert "rolling_pin" in names
     assert "image_orphan" in names
+    assert "role_registry_orphan" in names
 
 
 def test_image_plugin_group_matches_registry():
@@ -29,6 +30,11 @@ def test_role_unpinned_enabled_in_config():
 def test_image_orphan_enabled_in_config():
     cfg = yaml.safe_load(_CONFIG_PATH.read_text())
     assert cfg["plugins"]["image_orphan"]["enabled"] is True
+
+
+def test_role_registry_orphan_enabled_in_config():
+    cfg = yaml.safe_load(_CONFIG_PATH.read_text())
+    assert cfg["plugins"]["role_registry_orphan"]["enabled"] is True
 
 
 def test_rolling_pin_enabled_in_config():

--- a/tests/image_drift/test_role_registry_orphan.py
+++ b/tests/image_drift/test_role_registry_orphan.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+import pytest
+from osism_drift.config import Allowlist, AllowEntry, Config, PluginCfg, Remote
+from osism_drift.drift import role_registry_orphan
+
+FIXT = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def cfg():
+    return Config(
+        remote=Remote("https://x/", "https://y/", "main", "osism"),
+        base_dirs=(str(FIXT),),
+        release_version="latest",
+        plugins={"role_registry_orphan": PluginCfg(enabled=True)},
+        sources={},
+    )
+
+
+def _by_image(drifts):
+    return {d.image: d for d in drifts}
+
+
+def test_unreferenced_registry_var_detected(cfg):
+    """docker_registry_widget is defined in the widget role and referenced
+    nowhere — it must be flagged, pointing at the file that defines it."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_widget" in drifts
+    d = drifts["docker_registry_widget"]
+    assert d.alias == "widget"
+    assert d.found_src == "ansible-collection-services/roles/widget/defaults/main.yml"
+
+
+def test_own_definition_line_is_not_a_consumer(cfg):
+    """The widget fixture defines docker_registry_widget *as* a reference to
+    docker_registry_ansible. One line must prove both halves: the key being
+    defined does not count as consuming itself, while the value's reference
+    does count for the var it names."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_widget" in drifts
+    assert "docker_registry_ansible" not in drifts
+
+
+def test_reference_in_same_role_not_detected(cfg):
+    """docker_registry_adminer is consumed by another key in the same
+    defaults file — not an orphan."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_adminer" not in drifts
+
+
+def test_reference_from_another_role_not_detected(cfg):
+    """docker_registry_osism_frontend is defined in the manager role and
+    consumed in the netbox role — the scan spans roles, not just the
+    defining one."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_osism_frontend" not in drifts
+
+
+def test_bare_jinja_statement_reference_counts_as_consumer(cfg):
+    """docker_registry_loopy is consumed as a bare loop source
+    ({% for m in docker_registry_loopy %}), never as {{ ... }}. A consumer
+    pattern that only matched {{ var }} would false-flag it — as it would
+    the real docker_registry_mirrors in roles/docker."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_loopy" not in drifts
+
+
+def test_longer_name_does_not_mask_its_prefix(cfg):
+    """docker_registry_osism is unreferenced; docker_registry_osism_frontend
+    is referenced. The substring must not be read as a reference to the
+    shorter var, or the orphan disappears."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_osism" in drifts
+
+
+def test_playbook_reference_not_detected(cfg):
+    """docker_registry_pb is consumed only in ansible-playbooks-manager."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_pb" not in drifts
+
+
+def test_manager_template_reference_not_detected(cfg):
+    """docker_registry_gen is consumed only by the generics manager render
+    template, which renders it into every deployed images.yml."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_gen" not in drifts
+
+
+def test_base_docker_registry_var_is_not_reported(cfg):
+    """Bare docker_registry is the base override, not a per-image one; it is
+    outside the docker_registry_<alias> family this plugin scans."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry" not in drifts
+
+
+def test_non_text_files_are_not_read(cfg, monkeypatch):
+    """A docker_registry_<alias> reference lives only in ansible YAML or a
+    jinja template; every other file must be skipped unread (one remote GET
+    each in remote mode)."""
+    read_paths = []
+    real = role_registry_orphan.source.read_optional
+
+    def spy(repo, path, config):
+        read_paths.append(path)
+        return real(repo, path, config)
+
+    monkeypatch.setattr(role_registry_orphan.source, "read_optional", spy)
+    role_registry_orphan.run(cfg, Allowlist(()))
+    assert read_paths, "expected some consumer files to be read"
+    assert all(p.endswith((".yml", ".yaml", ".j2")) for p in read_paths)
+
+
+def test_allowlist_suppresses_orphan(cfg):
+    al = Allowlist(
+        (
+            AllowEntry(
+                plugin="role_registry_orphan",
+                image="docker_registry_widget",
+                alias=None,
+                found_src=None,
+                reason="intentional",
+            ),
+        )
+    )
+    drifts = _by_image(role_registry_orphan.run(cfg, al))
+    assert "docker_registry_widget" in drifts
+    assert drifts["docker_registry_widget"].allowlisted

--- a/tests/image_drift/test_role_registry_orphan.py
+++ b/tests/image_drift/test_role_registry_orphan.py
@@ -94,21 +94,12 @@ def test_base_docker_registry_var_is_not_reported(cfg):
     assert "docker_registry" not in drifts
 
 
-def test_non_text_files_are_not_read(cfg, monkeypatch):
-    """A docker_registry_<alias> reference lives only in ansible YAML or a
-    jinja template; every other file must be skipped unread (one remote GET
-    each in remote mode)."""
-    read_paths = []
-    real = role_registry_orphan.source.read_optional
-
-    def spy(repo, path, config):
-        read_paths.append(path)
-        return real(repo, path, config)
-
-    monkeypatch.setattr(role_registry_orphan.source, "read_optional", spy)
-    role_registry_orphan.run(cfg, Allowlist(()))
-    assert read_paths, "expected some consumer files to be read"
-    assert all(p.endswith((".yml", ".yaml", ".j2")) for p in read_paths)
+def test_consumer_in_an_unfiltered_file_is_found(cfg):
+    """docker_registry_shellcons is referenced only in
+    roles/shellcons/files/entrypoint.sh — not a .yml/.yaml/.j2 file. The scan
+    must read it, or a live registry override is reported for deletion."""
+    drifts = _by_image(role_registry_orphan.run(cfg, Allowlist(())))
+    assert "docker_registry_shellcons" not in drifts
 
 
 def test_allowlist_suppresses_orphan(cfg):


### PR DESCRIPTION
## What

Adds `role_registry_orphan`, a check for `docker_registry_<alias>` variables defined in an `ansible-collection-services` role's `defaults/main.yml` that nothing references — no role, no manager playbook, and not the generics manager render template.

## The two defects it already finds

Both are live on current main, both in `ansible-collection-services/roles/manager/defaults/main.yml`, on adjacent lines:

```
role_registry_orphan — 2 docker_registry_<alias> role defaults that nothing
references (orphaned registry overrides):

    docker_registry_osism_netbox, docker_registry_receptor

  Refs: ansible-collection-services/roles/, ansible-playbooks-manager/playbooks/, generics/environments/manager/
        ansible-collection-services/roles/manager/defaults/main.yml
```

**`docker_registry_osism_netbox`** (line 14) is the last remnant of the `osism-netbox` image being folded into the generic `osism` image:

- osism/ansible-collection-services#1775

That PR removed the role's use of the image but left three variables behind. Two were on the emitting side and are already gone; this one has outlived the image it points at by about 15 months.

**`docker_registry_receptor`** (line 15) is older. `manager: remove awx` deleted `receptor_tag` and `receptor_image` from that same defaults file and left the registry variable standing:

- osism/ansible-collection-services#605

```diff
-# receptor
-receptor_tag: devel
-receptor_image: "{{ docker_registry_receptor }}/ansible/receptor:{{ receptor_tag }}"
```

No `receptor` alias exists in `generics/environments/manager/images.yml` or `release/etc/images.yml`, and nothing under `roles/` references the variable. It has been dead since 2022-03-01 — about four and a half years.

Neither is merely untidy. Each is an operator-facing knob that silently does nothing: someone setting it is overriding the registry for an image the collection no longer resolves.

No allowlist entries are shipped. Cleaning up the two findings is deliberately left to a follow-up in `ansible-collection-services`, so the check is seen to produce the action.

## Why a new plugin rather than extending `image_orphan`

`image_orphan` starts from the **emitted** set — the `<alias>_tag:` lines in the generics manager template — minus what roles and playbooks consume. It works, and it fired: it drove the generics commit that removed the `nginx`, `osism_netbox` and `registry` emits.

But that is also why it never flagged these. Deleting the `osism_netbox_tag` emit removed the alias from the emitted set, and with it the plugin's only handle on the role default left behind. Every existing image-drift plugin walks the chain forward (release pin → render → role default); nothing walked backward from a role default to ask whether anything upstream still defines that alias. `role_registry_orphan` is that direction. The `receptor` remnant, four years older and from an unrelated removal, is evidence the gap is structural rather than specific to `osism_netbox`.

## Two details of the consumer match

Both came out of the real data, and both are covered by tests:

- **Bare names count, not only `{{ ... }}`.** `docker_registry_mirrors` is consumed as a loop source in `roles/docker/templates/daemon.json.j2` (`{% for mirror in docker_registry_mirrors %}`). A `{{ var }}`-only pattern — the one `image_orphan` uses for its own signal — would report it as dead.
- **A longer name does not mask its prefix.** `_` is a word character, so the `\b` anchor keeps `docker_registry_osism` from counting as referenced by an occurrence of `docker_registry_osism_frontend`. Without it the orphan silently disappears.

The generics manager template is scanned as a consumer because it renders `docker_registry_<alias>` into every deployed `images.yml`, so a variable used only there is genuinely consumed.

## The other two commits

**`docs: correct the remote-read cost model`** — the image doc described remote reads as one HTTP GET per file and advised `--base-dir` to avoid that cost. Not true since the archive backend landed: `archive.snapshot_dir()` fetches one tarball per `(repo, ref)`, extracts it, and serves every later read locally, memoized on `config.snapshot_cache` — which `driver.run` shares across every plugin in the run. The per-file path survives only behind `--use-raw-get`, which the periodic job does not pass. `archive`, `tarball` and `use-raw-get` appeared nowhere in `docs/`, so the backend was undocumented while the superseded behaviour was still described as current. Documented in the kolla doc, which the image doc already treats as canonical for input resolution.

**`drift: scan every consumer file, not just YAML`** — a latent defect in `image_orphan` that the stale cost model caused. Its consumer scan skipped anything not `.yml`/`.yaml`/`.j2`, justified in a comment as avoiding "one HTTP GET each". That saving does not exist, and the filter is not free: a consumer in a shell script under `files/` or an extension-less template makes an alias look unconsumed, and the remediation for an orphan is to delete a definition — so a false orphan deletes something live. Reading widely costs nothing in exchange; an unrelated file simply does not match. Removed from both plugins. The scan grows from 502 files to 575, under a megabyte total, and no finding changes.

## Verification

- 432 tests pass; 11 new for `role_registry_orphan`.
- `flake8`, `black`, `yamllint` clean at the CI-pinned versions.
- Both plugins run against local checkouts of the real repos: `image_orphan` reports nothing, `role_registry_orphan` reports exactly the two findings above.
- The plugin exits non-zero on findings, so `release-tox-drift` will report them in the periodic run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
