### PR TITLE
Build the kolla httpd image from 2025.2 on

### DIFF
--- a/latest/openstack-2025.2.yml
+++ b/latest/openstack-2025.2.yml
@@ -24,6 +24,7 @@ infrastructure_projects:
   grafana:
   hacluster:
   haproxy:
+  httpd:
   iscsid:
   keepalived:
   kolla-toolbox:

--- a/latest/openstack-2026.1.yml
+++ b/latest/openstack-2026.1.yml
@@ -24,6 +24,7 @@ infrastructure_projects:
   grafana:
   hacluster:
   haproxy:
+  httpd:
   iscsid:
   keepalived:
   kolla-toolbox:


### PR DESCRIPTION
kolla ships `docker/httpd` from `stable/2025.2` on, but `httpd` is in neither `openstack_projects` nor `infrastructure_projects`, and `container-images-kolla` derives its build set from exactly those two lists (`src/get-projects-from-versions-file.py`). The image is never requested, `kolla-build` never builds it, and there is no `httpd` repository on either registry at any tag.

The cleanest evidence that the build set is the sole cause is the pair on the same registry, same tag, same lane: `kolla/letsencrypt-webserver:2025.2` is present (it is in the list, via `letsencrypt:`), `kolla/httpd:2025.2` does not exist.

## Why it matters

Three kolla-ansible roles reference the image, and two are not optional:

| container | gated on | switched to httpd |
|---|---|---|
| `ironic-http` | **`enabled: true`, always** | 2026.1 (kolla-ansible `3d7a43391`) |
| `letsencrypt-webserver` | `enable_letsencrypt` | 2026.1 (`b9fc7a416`) — kolla deleted `docker/letsencrypt/letsencrypt-webserver` in the same cycle (`610eef208`) |
| `keystone-httpd` | `enable_keystone_federation` | 2025.2 (`3bffbca3c`) |

On 2025.2 only the keystone sidecar exists and can be avoided by staying on the Apache WSGI provider, so the gap is latent. 2026.1 dropped the WSGI provider switch and moved ironic and letsencrypt onto the image, so an ordinary ironic deployment now pulls an image that was never built. Both releases get the entry: 2025.2 to unblock federation on a release that is still built and published, 2026.1 because the image is mandatory there.

## Why one line is enough

- `docker/httpd/Dockerfile.j2` is `FROM base`, so the `KOLLA_IMAGES_BASE` loop in `004-build.sh` needs no new entry.
- The OSISM template override already supplies the `apache_footer` block that runs `a2enmod auth_openidc`, and in kolla `stable/2026.1` that block is defined in exactly one Dockerfile — `docker/httpd/`. The override was already aimed at an image nobody built.
- `docker/httpd/Dockerfile.j2` defines the generic `{% block labels %}`, so it inherits the `de.osism.release.openstack` stamp that `005-tag.sh` selects on. `images.txt` is generated at build time, so tag and push need no list update.
- No `versions.yml` pin is needed: nothing references `kolla_httpd_version`, and `httpd` is already allowlisted for `kolla_version_chain_upstream` as "apache supporting image, not independently pinned".
- `container-images-kolla` clones this repo unpinned from the default branch (`001-prepare.sh`), so no bump PR is needed there.

## Verification

Ran the real selector against the patched files rather than eyeballing the YAML — `^httpd` is now emitted for both releases (47 images each):

    OPENSTACK_VERSION=2025.2 python3 src/get-projects-from-versions-file.py | grep -x '\^httpd'

## Related

Building the image is not sufficient for letsencrypt on 2026.1; `osism/defaults` still overrides `letsencrypt_webserver_image` unconditionally:

- osism/defaults#305

## Upstream context

Upstream has the same filtered-build problem and solves it by keeping the image list next to the roles, changed in the same commit: `zuul.d/scenarios/{keystone-federation,ironic,lets-encrypt}.yaml` each carry `scenario_images_extra: ^httpd`. Their release builds are unfiltered, so `quay.io/openstack.kolla/httpd` exists for `2025.2-*`, `2026.1-*` and `master-*`.
