### PR TITLE
drift: check inventory at every release ref

### DIFF
--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -327,20 +327,32 @@ at the repo to edit.
 ### Plugin: kolla_inventory
 
 **Deployed — a deployed service must have inventory groups.** Compares the ansible group names (INI section headers) of upstream
-`openstack/kolla-ansible` `ansible/inventory/multinode` (at the pinned
-kolla-ansible ref, `stable/2025.2` by default)
-against the union of group names in the OSISM inventory files
-`generics/inventory/50-kolla` and `51-kolla`. A group present upstream but absent
-locally is flagged (one-way, upstream → local) — the failure mode behind
-generics#599 (neutron 2025.2 groups) and #601 (ironic-dnsmasq). Each flagged
-group's upstream **members** (child groups or hosts) ride in the `expected` field,
-so a red line tells a maintainer what to add. Subsumes the retired
-`check-kolla-inventory.py`.
+`openstack/kolla-ansible` `ansible/inventory/multinode` against the union of
+group names in the OSISM inventory files `generics/inventory/50-kolla` and
+`51-kolla`. A group present upstream but absent locally is flagged (one-way,
+upstream → local) — the failure mode behind generics#599 (neutron 2025.2 groups)
+and #601 (ironic-dnsmasq). Each flagged group's upstream **members** (child
+groups or hosts) ride in the `expected` field, so a red line tells a maintainer
+what to add. Subsumes the retired `check-kolla-inventory.py`.
+
+**Range-aware:** multinode is read at **every** supported release's resolved ref
+(`stable/<release>` → `unmaintained/` → `-eol` → `-eom`), not at the single
+pinned kolla-ansible ref, because OSISM ships one inventory for every release it
+builds while upstream renames groups per release. 2026.1 renamed
+`kolla-toolbox` → `kolla_toolbox` and `kolla-logs` → `kolla_logs`; the OSISM
+inventory keeps the hyphenated spelling, so those two 2026.1 plays select no
+hosts and deploy nothing — silently, with no failed task. A check pinned to one
+ref cannot see it. So the finding set is the **union** over the range: a group
+missing at *any* supported release is flagged, and a renamed group needs both
+spellings in the OSISM inventory for as long as both releases are supported.
+One entry per group (not per group-and-release, so the shipped allowlist keeps
+matching by bare group name), with the releases that want it named in
+`expected`; **members** come from the last release in the range order.
 
     python3 src/check-drift.py --group kolla --plugin kolla_inventory
 
-- **Reads:** `openstack/kolla-ansible` `ansible/inventory/multinode`;
-  `generics/inventory/50-kolla` and `51-kolla`.
+- **Reads:** `openstack/kolla-ansible` `ansible/inventory/multinode` (per
+  resolved release ref); `generics/inventory/50-kolla` and `51-kolla`.
 - **Fix:** add the group and its members to `50/51-kolla`; if the service is
   intentionally not deployed, add an allowlist entry with a reason (often
   `match: prefix` — see below). Base-infra groups the OSISM overlay assumes exist
@@ -403,6 +415,10 @@ reasons:
 - **Add direction** (e.g. `kolla_groupvars_missing`): a var is missing if
   upstream defines it at **any** supported release and OSISM lacks it — because
   that one defaults tip has to satisfy every supported release at once.
+
+`osism/generics` is single-tip in exactly the same way — one inventory serves
+every supported release — so `kolla_inventory` reads it at its tip and takes the
+same add-direction union over the per-release upstream `multinode`.
 
 ## Adding a plugin
 

--- a/src/drift-allowlist.yml
+++ b/src/drift-allowlist.yml
@@ -74,6 +74,7 @@ allow:
   - {plugin: kolla_inventory, image: tacker, match: prefix, reason: "not deployed in this series"}
   - {plugin: kolla_inventory, image: telegraf, match: prefix, reason: "not deployed in this series"}
   - {plugin: kolla_inventory, image: collectd, match: prefix, reason: "not deployed in this series"}
+  - {plugin: kolla_inventory, image: venus, match: prefix, reason: "not deployed in this series; enable_venus is no and upstream dropped it after 2025.1"}
   # --- kolla_enablement_orphan ---
   # OSISM-invented enable flags with no upstream counterpart by design (not a
   # removed-upstream service). The check uses explicit scope -- it flags every

--- a/src/osism_drift/drift/kolla_inventory.py
+++ b/src/osism_drift/drift/kolla_inventory.py
@@ -1,36 +1,56 @@
 """kolla_inventory: detect upstream ansible inventory groups missing locally.
 
 Compares the group (INI section) names of upstream openstack/kolla-ansible
-ansible/inventory/multinode (at the pinned kolla-ansible source ref) against the
-union of group names in the OSISM inventory files generics/inventory/50-kolla
-and 51-kolla. A group present upstream but absent locally is flagged, and its
-upstream members ride in `expected` so a maintainer knows what to add.
+ansible/inventory/multinode against the union of group names in the OSISM
+inventory files generics/inventory/50-kolla and 51-kolla. A group present
+upstream but absent locally is flagged, and its upstream members ride in
+`expected` so a maintainer knows what to add.
+
+Range-aware: multinode is read at every supported release's resolved ref
+(source.release_to_ref), not at the single pinned kolla-ansible ref, because
+OSISM ships ONE inventory for every release it builds while upstream renames
+groups per release. 2026.1 renamed kolla-toolbox -> kolla_toolbox and
+kolla-logs -> kolla_logs; the OSISM inventory keeps the hyphenated spelling, so
+those two 2026.1 plays select no hosts and deploy nothing, silently. A
+single-ref check pinned to an older release cannot see that at all, which is
+why the group is the union over the range: a group missing at ANY supported
+release is a finding, and a renamed group needs both spellings in the OSISM
+inventory for as long as both releases are supported.
+
+One entry per group rather than per (group, release) — the fix is to add the
+group to the OSISM inventory once — with the releases that want it named in
+`expected`/`expected_src`. Members come from the last release in the range
+order (the newest, for the default sorted range), the spelling a maintainer is
+adding for.
 
 The comparison is one-way (upstream -> local). Intentional omissions are
 covered by the allowlist (exact base groups plus prefix not-deployed
 services).
 """
 
-from osism_drift import inventory_sections, source
+from osism_drift import enablement, inventory_sections, source
 from osism_drift.model import DriftEntry
 
 NAME = "kolla_inventory"
 DESCRIPTION = (
     "Flag ansible inventory groups in upstream kolla-ansible multinode "
-    "that are absent from the OSISM 50/51-kolla inventory."
+    "at any supported release that are absent from the OSISM 50/51-kolla "
+    "inventory."
 )
 INPUT_FILES = [
-    ("kolla_ansible", "ansible/inventory/multinode"),
+    ("kolla_ansible", "ansible/inventory/multinode (per resolved release ref)"),
     ("generics", "inventory/50-kolla"),
     ("generics", "inventory/51-kolla"),
 ]
 SUMMARY = (
     "{n} ansible inventory groups present in upstream kolla-ansible multinode "
-    "but missing from the OSISM 50/51-kolla inventory:"
+    "at a supported release but missing from the OSISM 50/51-kolla inventory:"
 )
 REMEDIATION = (
     "add the group and its members to generics/inventory/50-kolla or 51-kolla, "
-    "or allowlist it if the service is intentionally not deployed."
+    "or allowlist it if the service is intentionally not deployed. A group "
+    "upstream renamed (kolla-toolbox -> kolla_toolbox in 2026.1) needs BOTH "
+    "spellings for as long as both releases are supported."
 )
 
 _MULTINODE = "ansible/inventory/multinode"
@@ -39,31 +59,53 @@ _51 = "inventory/51-kolla"
 _FOUND_SRC = "generics/inventory/{50,51}-kolla"
 
 
-def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
-    """Return drifts for kolla-ansible inventory groups missing from OSISM."""
-    ref = source.current_ref("kolla_ansible", config)
-    expected_src = f"openstack/kolla-ansible/ansible/inventory/multinode @ {ref}"
-    upstream = inventory_sections.parse_groups(
-        source.read("kolla_ansible", _MULTINODE, config)
-    )
-    local = set(
+def _local_groups(config) -> set:
+    """Group names the OSISM inventory defines, across 50-kolla and 51-kolla."""
+    return set(
         inventory_sections.parse_groups(source.read("generics", _50, config))
     ) | set(inventory_sections.parse_groups(source.read("generics", _51, config)))
 
+
+def run(config, allowlist, verbose: bool = False) -> list[DriftEntry]:
+    """Return drifts for kolla-ansible inventory groups missing from OSISM."""
+    releases = enablement.release_range(config)
+    if not releases:
+        # No release means no multinode is read at all, so EVERY missing group
+        # goes unreported (and every allowlist entry goes stale). Fail loud.
+        raise source.SourceError(
+            "empty supported release range; cannot compare against upstream "
+            "kolla-ansible multinode"
+        )
+
+    local = _local_groups(config)
+    where = {}  # group -> ["<release> (<ref>)", ...], in range order
+    members = {}  # group -> members at the last release that wants it
+
+    for release in releases:
+        ref = source.release_to_ref("kolla_ansible", release, config)
+        upstream = inventory_sections.parse_groups(
+            source.read_at_ref("kolla_ansible", _MULTINODE, ref, config)
+        )
+        for group in sorted(set(upstream) - local):
+            where.setdefault(group, []).append(f"{release} ({ref})")
+            members[group] = upstream[group]
+
     drifts = []
-    for group in sorted(set(upstream) - local):
-        members = upstream[group]
-        member_str = ", ".join(members) if members else "(none)"
+    for group in sorted(where):
+        at = ", ".join(where[group])
+        member_str = ", ".join(members[group]) if members[group] else "(none)"
         d = DriftEntry(
             plugin=NAME,
             image=group,
             alias=group,
             expected=(
-                "present in upstream kolla-ansible multinode at "
-                f"{ref}; members: {member_str}"
+                f"present in upstream kolla-ansible multinode at {at}; "
+                f"members: {member_str}"
             ),
             found="absent from OSISM inventory (50-kolla/51-kolla)",
-            expected_src=expected_src,
+            expected_src=(
+                f"openstack/kolla-ansible/ansible/inventory/multinode @ {at}"
+            ),
             found_src=_FOUND_SRC,
         )
         drifts.append(allowlist.apply(d))

--- a/src/osism_drift/drift/kolla_inventory.py
+++ b/src/osism_drift/drift/kolla_inventory.py
@@ -39,6 +39,10 @@ DESCRIPTION = (
 )
 INPUT_FILES = [
     ("kolla_ansible", "ansible/inventory/multinode (per resolved release ref)"),
+    # The supported release range comes from the release manifests, so this repo
+    # has to resolve too: undeclared, the pre-flight check passes and the run
+    # dies mid-comparison on a repo it never announced it needed.
+    ("release", "latest/openstack-*.yml (supported release range)"),
     ("generics", "inventory/50-kolla"),
     ("generics", "inventory/51-kolla"),
 ]

--- a/tests/kolla_drift/test_kolla_inventory.py
+++ b/tests/kolla_drift/test_kolla_inventory.py
@@ -1,25 +1,62 @@
 from pathlib import Path
 import pytest
-from osism_drift.config import Allowlist, AllowEntry, Config, Remote, PluginCfg
+import responses
+from osism_drift.config import (
+    Allowlist,
+    AllowEntry,
+    Config,
+    PluginCfg,
+    Remote,
+    SourceCfg,
+)
 from osism_drift.drift import kolla_inventory as plugin
 
 FIXT = Path(__file__).parent / "fixtures"
+API = "https://api.github.com/repos"
+RAW = "https://raw.githubusercontent.com"
+
+# FIXT/generics/inventory/{50,51}-kolla define: control, nova:children, compute.
+LOCAL_GROUPS = "control, nova:children, compute"
 
 
-@pytest.fixture
-def cfg():
-    # kolla_ansible is NOT pinned here, so it reads the local fixture (offline).
+def _cfg(releases=("A", "B"), base_dirs=(str(FIXT),)):
     return Config(
-        remote=Remote("https://raw/", "https://api/", "main", "osism"),
-        base_dirs=(str(FIXT),),
+        remote=Remote(f"{RAW}/", f"{API}/", "main", "osism"),
+        base_dirs=base_dirs,
+        # FIXT/kolla-ansible is a plain dir, not a git checkout, and the repo is
+        # pinned -> it cannot be served from named refs locally, so it falls to
+        # the mocked remote.
+        remote_fallback=True,
         release_version="latest",
         plugins={"kolla_inventory": PluginCfg(enabled=True)},
-        sources={},
+        sources={"kolla_ansible": SourceCfg(owner="openstack", branch="stable/2025.2")},
+        releases=releases,
     )
 
 
-def test_flags_upstream_only_groups(cfg):
-    drifts = plugin.run(cfg, Allowlist(()))
+def _mock_release(release, multinode):
+    """Serve upstream multinode for one release at its probed stable/ ref."""
+    ref = f"stable/{release}"
+    responses.add(
+        responses.GET, f"{API}/openstack/kolla-ansible/commits/{ref}", status=200
+    )
+    responses.add(
+        responses.GET,
+        f"{RAW}/openstack/kolla-ansible/{ref}/ansible/inventory/multinode",
+        body=multinode.encode(),
+        status=200,
+    )
+
+
+@responses.activate
+def test_flags_upstream_only_groups_across_the_release_range():
+    # The finding set is the union over the range: neither release alone holds
+    # all three, and a single-ref check would report only one release's share.
+    _mock_release(
+        "A", "[cyborg:children]\ncyborg-agent\n\n[cyborg-agent:children]\ncompute\n"
+    )
+    _mock_release("B", "[ironic-dnsmasq:children]\ncontrol\n")
+    drifts = plugin.run(_cfg(), Allowlist(()))
     assert sorted(d.image for d in drifts) == [
         "cyborg-agent:children",
         "cyborg:children",
@@ -27,23 +64,64 @@ def test_flags_upstream_only_groups(cfg):
     ]
 
 
-def test_expected_src_uses_configured_ref(cfg):
-    # kolla_ansible is unpinned here, so the ref is the remote default branch
-    # (main) — the label must be config-derived, not a hardcoded stable/2025.2.
-    drifts = plugin.run(cfg, Allowlist(()))
-    assert drifts
-    assert all(d.expected_src.endswith("@ main") for d in drifts)
-    assert all("2025.2" not in d.expected_src for d in drifts)
+@responses.activate
+def test_entry_names_only_the_releases_that_want_the_group():
+    _mock_release("A", "[control]\nctl01\n")  # nothing missing
+    _mock_release("B", "[ironic-dnsmasq:children]\ncontrol\n")
+    drifts = plugin.run(_cfg(), Allowlist(()))
+    d = next(d for d in drifts if d.image == "ironic-dnsmasq:children")
+    assert "B (stable/B)" in d.expected
+    assert d.expected_src.endswith("multinode @ B (stable/B)")
+    assert "A (stable/A)" not in d.expected_src
 
 
-def test_red_entry_carries_members(cfg):
-    drifts = plugin.run(cfg, Allowlist(()))
+@responses.activate
+def test_group_renamed_upstream_is_flagged_at_the_release_that_renamed_it(tmp_path):
+    # The 2026.1 kolla-toolbox -> kolla_toolbox rename: OSISM ships one inventory
+    # for every supported release, so the old spelling matching an older release
+    # must not hide the new spelling the newer release selects on. A check pinned
+    # to one ref sees at most one of the two.
+    inv = tmp_path / "generics" / "inventory"
+    inv.mkdir(parents=True)
+    (inv / "50-kolla").write_text("[control]\nctl01\n")
+    (inv / "51-kolla").write_text("[kolla-toolbox:children]\ncontrol\n")
+    _mock_release("A", "[kolla-toolbox:children]\ncontrol\n")
+    _mock_release("B", "[kolla_toolbox:children]\ncontrol\n")
+    drifts = plugin.run(_cfg(base_dirs=(str(tmp_path), str(FIXT))), Allowlist(()))
+    assert [d.image for d in drifts] == ["kolla_toolbox:children"]
+    assert "B (stable/B)" in drifts[0].expected
+
+
+@responses.activate
+def test_members_come_from_the_last_release_that_wants_the_group():
+    # Members tell a maintainer what to add, so they must describe the newest
+    # release's shape, not a stale earlier one.
+    _mock_release("A", "[ironic-dnsmasq:children]\nnetwork\n")
+    _mock_release("B", "[ironic-dnsmasq:children]\ncontrol\n")
+    drifts = plugin.run(_cfg(), Allowlist(()))
+    assert len(drifts) == 1
+    assert "members: control" in drifts[0].expected
+    assert "network" not in drifts[0].expected
+
+
+@responses.activate
+def test_red_entry_carries_members():
+    _mock_release("A", "[control]\nctl01\n")
+    _mock_release("B", "[ironic-dnsmasq:children]\ncontrol\n")
+    drifts = plugin.run(_cfg(), Allowlist(()))
     red = next(d for d in drifts if d.image == "ironic-dnsmasq:children")
     assert "members:" in red.expected
     assert "control" in red.expected
 
 
-def test_exact_and_prefix_allowlist_match(cfg):
+@responses.activate
+def test_exact_and_prefix_allowlist_match():
+    # The entry key stays the bare group name across the range change, so the
+    # shipped allowlist keeps matching; a per-release key would strand all of it.
+    _mock_release(
+        "A", "[cyborg:children]\ncyborg-agent\n\n[cyborg-agent:children]\ncompute\n"
+    )
+    _mock_release("B", "[ironic-dnsmasq:children]\ncontrol\n")
     al = Allowlist(
         (
             AllowEntry(
@@ -54,10 +132,22 @@ def test_exact_and_prefix_allowlist_match(cfg):
             ),
         )
     )
-    drifts = plugin.run(cfg, al)
+    drifts = plugin.run(_cfg(), al)
     by = {d.image: d for d in drifts}
     assert by["cyborg:children"].allowlisted is True  # prefix matches the service group
     assert (
         by["cyborg-agent:children"].allowlisted is True
     )  # prefix covers the sub-group
     assert by["ironic-dnsmasq:children"].allowlisted is False
+
+
+def test_empty_release_range_raises(tmp_path):
+    from osism_drift.source import SourceError
+
+    # An empty range reads no multinode at all, so every missing group would go
+    # unreported: the detector must fail loud instead of reporting clean.
+    empty = tmp_path / "release" / "latest"
+    empty.mkdir(parents=True)
+    cfg = _cfg(releases=(), base_dirs=(str(tmp_path), str(FIXT)))
+    with pytest.raises(SourceError, match="empty supported release range"):
+        plugin.run(cfg, Allowlist(()))

--- a/tests/kolla_drift/test_kolla_inventory.py
+++ b/tests/kolla_drift/test_kolla_inventory.py
@@ -151,3 +151,33 @@ def test_empty_release_range_raises(tmp_path):
     cfg = _cfg(releases=(), base_dirs=(str(tmp_path), str(FIXT)))
     with pytest.raises(SourceError, match="empty supported release range"):
         plugin.run(cfg, Allowlist(()))
+
+
+def test_declares_the_release_repo_it_reads(tmp_path):
+    from osism_drift.source import SourceError
+
+    # The release range is read from the release manifests, so `release` must be
+    # in INPUT_FILES: the driver's pre-flight resolution keys off that list, and
+    # an undeclared repo turns a clean "not found under any --base-dir" into a
+    # failure mid-comparison.
+    assert (
+        "release",
+        "latest/openstack-*.yml (supported release range)",
+    ) in plugin.INPUT_FILES
+
+    inv = tmp_path / "generics" / "inventory"
+    inv.mkdir(parents=True)
+    (inv / "50-kolla").write_text("[control]\nctl01\n")
+    (inv / "51-kolla").write_text("[control]\nctl01\n")
+    # remote_fallback stays off so the missing repo raises offline instead of
+    # reaching for the network.
+    cfg = Config(
+        remote=Remote(f"{RAW}/", f"{API}/", "main", "osism"),
+        base_dirs=(str(tmp_path),),
+        release_version="latest",
+        plugins={"kolla_inventory": PluginCfg(enabled=True)},
+        sources={},
+        releases=(),
+    )
+    with pytest.raises(SourceError, match="repo 'release' not found"):
+        plugin.run(cfg, Allowlist(()))


### PR DESCRIPTION
`kolla_inventory` compared upstream kolla-ansible's `ansible/inventory/multinode`
against `generics/inventory/50-kolla` + `51-kolla` at a **single** ref —
`sources.kolla_ansible.branch`, `stable/2025.2` by default. But `osism/generics`
is single-tip: one inventory serves every release OSISM builds, while upstream
renames groups per release. A one-ref comparison can only ever vet one of the
releases that inventory has to satisfy, and it vets the wrong one as soon as the
pin lags the newest supported release.

This reads multinode at **every** supported release's resolved ref
(`release_range` + `release_to_ref`, as the other range-aware plugins do) and
takes the union: a group missing at *any* supported release is a finding, because
that one inventory must satisfy all of them at once.

## Findings against `main` (unfixed): 8 actionable

```
kolla_inventory — 8 ansible inventory groups present in upstream kolla-ansible
multinode at a supported release but missing from the OSISM 50/51-kolla
inventory:

    cinder-backup-lvm, cinder-backup-multiple, cinder-volume-lvm,
    cinder-volume-multiple, kolla_logs, kolla_toolbox,
    prometheus-openstack-network-exporter, prometheus-valkey-exporter

  Refs: openstack/kolla-ansible/ansible/inventory/multinode @ 2026.1 (stable/2026.1)
        generics/inventory/{50,51}-kolla
```

All eight are 2026.1. `kolla_logs` / `kolla_toolbox` are a **rename** upstream
(`kolla-logs` / `kolla-toolbox` ≤2025.2), which the OSISM inventory did not
follow, so those two 2026.1 plays select zero hosts and deploy nothing — silently,
with no failed task. The check pinned to `stable/2025.2` could not see any of it.

The fix for all eight:

- osism/generics#616

With that applied the plugin reports `0 to act on, 0 advisory, 19 allowlisted, 0
stale entries`.

## Also in this change

- **`venus` allowlisted.** Looking at older releases surfaces
  `venus-{api,manager}` at 2024.1–2025.1, which OSISM does not deploy
  (`enable_venus: "no"`, and the site.yml splitter lists venus unsupported), so
  they join `cyborg` / `tacker` / `telegraf` / `collectd` as not-deployed. This
  also **un-stales the `telegraf` entry**, which was dead while the check only
  looked at 2025.2.
- **Entries stay keyed on the bare group name**, not group-and-release, so the
  fix stays "add it to the inventory once" and the 15 shipped allowlist entries
  keep matching unchanged. The releases that want a group ride in
  `expected` / `expected_src`, which also groups the report by release.
- **Members come from the last release in the range order** — the newest, hence
  the spelling a maintainer is adding for.
- **An empty release range now raises** rather than reporting clean, matching
  `kolla_enablement_orphan`: with no release there is no multinode to read and
  every missing group would go unreported.

`2026.1` resolves to `stable/2026.1`, which upstream has already branched off
master, so this compares against the ref the image actually builds from — not
against not-yet-released groups on master.

## Test change

The plugin's own test moves from reading the local multinode fixture to mocking
one per release ref, since per-ref reads cannot come from an unpinned working
tree. New guard: local inventory holding `kolla-toolbox` must not hide upstream's
`kolla_toolbox` at the newer release. 423 tests pass.

## Follow-up, not in this PR

`osism/generics` still ships its own single-branch copy of this check
(`src/check-kolla-inventory.py`, `KOLLA_BRANCH = "stable/2025.2"`, wired as
`generics-tox-check-kolla` in `check` + periodic). It merged 2026-06-30, one day
before this plugin landed and claimed to subsume it, so the duplication is an
accident of sequencing. Retiring the generics implementation while keeping a
generics-side **gate** — a `check` job with `required-projects: [osism/release]`
running this plugin against the *proposed* inventory, which a periodic job in this
repo structurally cannot do — is in flight as:

- osism/generics#617

That PR invokes this plugin, so merging it before this one means the gate checks
one release instead of five. It is not a hard dependency in the other direction. Note that
naively bumping the generics pin to `stable/2026.1` instead would fail that job
outright: `telegraf` is gone from multinode at 2026.1, so its stale-ignore guard
exits 3.

