### PR TITLE
drift: close the plugin documentation gaps

### DIFF
--- a/docs/check-drift-image.md
+++ b/docs/check-drift-image.md
@@ -355,4 +355,6 @@ See the kolla doc's [Adding a plugin](check-drift-kolla.md#adding-a-plugin)
 section for the full recipe. For image-group plugins, register the module in
 `IMAGE_PLUGINS = [...]` in `src/osism_drift/drift/__init__.py` **and** add a
 `plugins.<NAME>: {enabled: true}` stanza to `src/drift-config.yml`.
-Mirror the test pattern in `tests/image_drift/`.
+Mirror the test pattern in `tests/image_drift/`, and give the plugin a section
+of its own in this doc's [Plugins](#plugins) — that is part of adding it, not a
+follow-up.

--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -82,11 +82,59 @@ stage or the transition into it:
    versions template and the producer's SBOM map.
 4. **deployed** — the service has ansible inventory groups to deploy into.
 
+One check sits ahead of the stages: `kolla_source_ref_phase` asks whether the
+sources a build consumes are still maintained upstream, which is a property of
+the release manifest rather than of any one service.
+
 The plugins run in that order, and the report renders them the same way.
 Each opens with the stage it guards. Each is independent and can be run alone
 with `--plugin <name>`; every finding can be suppressed with an allowlist entry
 (see "Allowlist"). Service names are compared as **key spaces**, normalising
 `-`↔`_`; the checks never derive keys from output-variable or image names.
+
+### Plugin: kolla_source_ref_phase
+
+**Sourced — a build must consume sources upstream still regenerates.** For every
+supported release, compares each `openstack_projects` ref in `osism/release`
+`latest/openstack-<release>.yml` against the latest lifecycle phase opendev
+actually publishes a tarball for. Upstream renames `stable/<release>` to
+`unmaintained/<release>` and deletes the branch at EOL, but
+tarballs.opendev.org goes on **serving** a retired name while it stops
+**regenerating** it: a build still asking for
+`<project>-stable-<release>.tar.gz` keeps succeeding, with its sources frozen at
+the moment of the rename. Nothing fails, so nothing prompts the move.
+
+The check is artifact-driven rather than branch-driven. The question is which
+tarball the build consumes, and probing the published set answers it directly:
+no upstream repository owner is needed per project, and the check self-limits at
+EOL, where no later artifact exists and the frozen tarball is the only option.
+Existence is one HEAD per candidate phase rather than a read of the per-project
+index, because those listings are large (nova's is ~1.4 MB and 10k entries) and
+timed out intermittently in practice, which for a nightly check means noise. A
+ref that does not name the release is skipped: a project on its own branch
+scheme (e.g. gnocchi at `stable/4.6`) does not follow the release lifecycle.
+
+A probe that neither confirms nor denies — an outage, a throttled response —
+leaves that ref **unverified** rather than clean, reported in its own block with
+the failure kind. Reading "could not find out" as "no later phase is published"
+would silently reinstate the blind spot this check closes; marking the affected
+refs instead of aborting keeps one upstream hiccup from discarding every other
+finding in the run.
+
+Because the answer is what upstream publishes right now, no `--base-dir` can
+stand in for it: the plugin declares `tarballs.opendev.org` in `EXTERNAL_HOSTS`,
+and the driver refuses a local-only run that selects this plugin rather than
+reaching the network unannounced.
+
+    python3 src/check-drift.py --group kolla --plugin kolla_source_ref_phase
+
+- **Reads:** `osism/release` `latest/openstack-<release>.yml` per supported
+  release; `tarballs.opendev.org/openstack/<project>/` (one HEAD per candidate
+  phase).
+- **Fix:** set the ref to the latest published phase in
+  `latest/openstack-<release>.yml`, and drop any downstream patch the newer
+  sources already carry. Allowlist a project deliberately pinned to a frozen
+  tarball.
 
 ### Plugin: kolla_enablement_orphan
 

--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -493,3 +493,10 @@ test guards that every registered plugin is enabled). A new repo needs no config
 it is fetched remotely by default, or discovered by name under a `--base-dir`.
 Mirror the test pattern in `tests/kolla_drift/`: synthetic fixtures laid out as
 `fixtures/<repo-dir>/...` plus a `Config(..., base_dirs=(str(FIXT),))`.
+
+Then **document it in the group's doc**: a section of its own alongside the
+other plugins, opening with the stage it guards, then the command, then the
+**Reads:** and **Fix:** bullets. This is part of adding a plugin, not a
+follow-up. `kolla_source_ref_phase` merged without a section, which left its
+module docstring as the only description of a check an operator meets as a red
+line in a nightly report — and nothing about the run points at that docstring.

--- a/docs/check-drift-kolla.md
+++ b/docs/check-drift-kolla.md
@@ -202,7 +202,7 @@ verbatim (an Ansible var name is an exact identifier).
 ### Plugin: kolla_mirror_verbatim
 
 **Enabled — `001` must stay a verbatim mirror of upstream-newest.** Enforces
-Convention X: `osism/defaults` `all/001-kolla-defaults.yml` must equal upstream
+Convention X: the `osism/defaults` `all/001-*.yml` **layer** must equal upstream
 kolla-ansible `group_vars/all` at the **newest** supported release
 (`release_range[-1]`, `stable/2025.2` today), compared as parsed YAML values
 (jinja lives in string values and compares as strings). Every OSISM opinion lives
@@ -211,11 +211,23 @@ group_var. The sibling `kolla_groupvars_missing` only proves the upstream *union
 is *supplied somewhere* — it cannot see values or which file a key sits in, so it
 cannot keep `001` pure; this check does.
 
+The mirror is a **layer, not a file**: `001-aodh.yml`, `001-common.yml`,
+`001-database.yml` … mirror upstream's own split `group_vars/all/*.yml` names,
+and the layer is read as their merge in lexical filename order with the last
+file defining a key winning — Ansible's own group_vars merge order, which
+upstream itself relies on (it defines the seven `database_*` keys in both
+`common.yml` and `database.yml`, and `database.yml` wins). Comparing the merged
+layer rather than one file is what lets the mirror be split per upstream service
+without the check having to know how it was split.
+
 Each deviation is one of three shapes, and the finding prints the exact
 destination to move the key to:
 
 - **absent from `001`** (upstream-newest defines it) → mirror the upstream
-  key+value verbatim into `001`.
+  key+value verbatim into the `001` file matching the upstream file the key
+  lives in (`all/001-<upstream group_vars file>`), or into the layer
+  (`all/001-*.yml`) when upstream has no per-service home to name — the
+  monolithic `group_vars/all.yml` layout of 2025.1 and earlier.
 - **value differs** → restore the upstream value in `001`; put OSISM's value in
   `099-*` (plain, or an `openstack_version` gate if it varies by release).
 - **in `001`, not upstream-newest** → remove from `001` and route it: **delete**
@@ -226,9 +238,11 @@ destination to move the key to:
 
     python3 src/check-drift.py --group kolla --plugin kolla_mirror_verbatim
 
-- **Reads:** `osism/defaults` `all/001-kolla-defaults.yml`; `openstack/kolla-ansible`
-  `group_vars/all` at the newest release's resolved ref (plus each older release's
-  keys, to classify a dropped key and pick its `010-<L>` home).
+- **Reads:** `osism/defaults` `all/001-*.yml` (the whole layer, merged in
+  filename order); `openstack/kolla-ansible` `group_vars/all` at the newest
+  release's resolved ref, with the filename each key comes from (to name the
+  destination file), plus each older release's keys (to classify a dropped key
+  and pick its `010-<L>` home).
 - **Fix:** as printed per shape — mirror into `001`, or move the OSISM delta to
   `099-*` (opinions) / `010-<L>.yml` (dropped upstream keys). Never allowlist a
   group_var (Convention X).


### PR DESCRIPTION
The drift docs promise a complete roster — `## The checks` says the plugins run
in registry order and "the report renders them the same way", and each one gets
a `### Plugin: <name>` section — but nothing enforces it, and two gaps had
opened:

- `kolla_source_ref_phase` merged with no section at all, so the only
  description of the check was its module docstring.
- the `kolla_mirror_verbatim` section still described a single
  `all/001-kolla-defaults.yml`, which the mirror-layer series (74ac6e5f..9edc1608)
  replaced with a per-service `all/001-*.yml` layer.

The docstring is not the operator-facing surface. A maintainer meets a check as
a red line in the nightly `release-tox-drift` report and goes to the group doc;
nothing in the run points at a module docstring.

## Why it happened, and what stops it

`## Adding a plugin` in the kolla doc is the canonical recipe — the image doc and
the new catalog doc both defer to it. It listed the module contract, the registry
entry, the config stanza and the test pattern. It never said to document the
check. The one step missing from the recipe is the one that got missed, twice.

This adds the step, in the kolla recipe and in the image doc's short form, and
says what a section consists of (stage lead, command, `Reads:`/`Fix:` bullets) so
it reads as a requirement rather than a reminder to be thorough.

It is prose, not enforcement: a plugin can still merge undocumented. A tolerant
registry test — every registered plugin's name appears in some heading under
`docs/`, no fixed file or heading level — would close that, and would survive the
restructure this file is heading for. Left out of this PR deliberately; happy to
add it.

## Commits

- `docs: document kolla_source_ref_phase` — what it compares (each
  `openstack_projects` ref against the latest lifecycle phase opendev still
  publishes a tarball for), why it probes artifacts rather than branches, why an
  inconclusive probe reports *unverified* rather than clean, and why no
  `--base-dir` can stand in for it (`EXTERNAL_HOSTS`, a property no other kolla
  plugin has and one an operator currently discovers as an error message).
- `docs: read the 001 mirror as a layer` — the layer, its lexical merge order and
  why that matters (upstream defines the `database_*` keys in both `common.yml`
  and `database.yml` and relies on `database.yml` winning), and the fallback to
  the layer glob for the monolithic upstream layout of 2025.1 and earlier.
- `docs: make documenting a plugin part of adding one` — the recipe step.

The four-stage framing in `## The checks` describes a kolla *service*, and
`kolla_source_ref_phase` is about the release manifest rather than any one
service, so it is introduced as sitting ahead of the stages instead of being
renumbered into the list.

## Merge order for the queue behind this

Docs-only, no behaviour change, and deliberately placed first so the queued
plugin PRs land against a doc that already asks them for a section. I
test-merged this branch against each of them in both directions, then all five
sequentially:

    drift-docs-plugin-coverage → 2685 → 2693 → 2690 → 2643

- osism/release#2685
- osism/release#2693
- osism/release#2690
- osism/release#2643

Everything is clean except one unavoidable collision between the last two:
2643 and 2690 both append their `plugins:` stanza at EOF of
`src/drift-config.yml`. It fires in either order; keeping both lines resolves
it. 2643 goes last because it is a draft and 19 commits behind, so it absorbs
that one line in the rebase it needs anyway — and picks up its own doc section
there. Verified end state of all five merged: 529 passed, 2 skipped, lint clean.

## Verification

`tox -e drift-test` on this branch: 420 passed. flake8, black and yamllint clean.
No source changes, so no drift run is affected.

## Note for a reviewer

`docs/check-drift-kolla.md` is 512 lines after this, with 13 plugin sections in
one file, and the queued PRs add ~40 more. These commits are additive and do not
depend on the current layout, so a later split (one file per plugin, group docs
keeping run/input-resolution/allowlist/release-model) does not have to unpick
them.
