### PR TITLE
source: memoize remote ref existence probes

### DIFF
--- a/src/osism_drift/config.py
+++ b/src/osism_drift/config.py
@@ -73,6 +73,9 @@ class Config:  # pylint: disable=too-many-instance-attributes  # data record
     playbooks_cache: dict = field(
         default_factory=dict
     )  # per-run release -> {role: frozenset(environments)}
+    ref_exists_cache: dict = field(
+        default_factory=dict
+    )  # per-run (repo, ref) -> bool memo of remote existence probes
 
 
 def load_config(path) -> Config:

--- a/src/osism_drift/source.py
+++ b/src/osism_drift/source.py
@@ -387,19 +387,39 @@ def list_dir_at_ref(
 
 def ref_exists(repo: str, ref: str, config) -> bool:
     """True if `ref` (branch/tag/sha) resolves in the upstream repo (local clone
-    when it resolves under a --base-dir, else the GitHub commits API)."""
+    when it resolves under a --base-dir, else the GitHub commits API).
+
+    Remote answers are memoized on config.ref_exists_cache, keyed by (repo, ref),
+    because callers re-ask the same question many times in one run: osism_files()
+    re-checks playbooks_version on every call, and runtime_interface() is
+    memoized per release while osism_interface() is release-independent, so the
+    same probe is repeated per caller. Each probe is one request against the
+    GitHub core API budget -- 60/hr unauthenticated -- and that is what a run
+    crossed, spending 70 of its 86 budgeted requests re-asking whether one
+    playbooks_version tag exists, then aborting mid-run before it reported any
+    drift.
+
+    Absence is memoized too, so that release_to_ref()'s walk through its
+    candidate list does not pay for its misses again on a later resolve (only
+    the hit is memoized there). Local checkouts are not memoized: they answer
+    from the clone at no request cost, and stay live for a caller that reads a
+    working tree.
+    """
     where, d = _resolve(repo, config)
     if where == "local" and _is_pinned(repo, config):
         return _git_ref_exists(d, ref)
+    key = (repo, ref)
+    if key in config.ref_exists_cache:
+        return config.ref_exists_cache[key]
     owner = _owner(repo, config)
     url = f"{config.remote.github_api}{owner}/{repo.replace('_', '-')}/commits/{ref}"
     _note("ref?", repo, ref)
     r = _get("checking ref", url, json_api=True, ok=(404, 422))
     # GitHub's commits API returns 422 (not 404) for a ref that does not
     # resolve; treat both as "absent" so the resolver probes the next candidate.
-    if r.status_code in (404, 422):
-        return False
-    return True
+    exists = r.status_code not in (404, 422)
+    config.ref_exists_cache[key] = exists
+    return exists
 
 
 _REF_CANDIDATES = ("stable/{r}", "unmaintained/{r}", "{r}-eol", "{r}-eom")

--- a/tests/kolla_drift/test_source.py
+++ b/tests/kolla_drift/test_source.py
@@ -1266,3 +1266,59 @@ def test_read_at_ref_uses_archive(tmp_path):
         read_at_ref("release", "nope.yml", "stable/2025.2", cfg, optional=True) is None
     )
     assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_ref_exists_memoizes_probes(tmp_path):
+    """A repeated existence probe costs one request, not one per call.
+
+    Callers re-ask the same question many times per run -- osism_files()
+    re-checks playbooks_version on every call (playbooks.py) -- and each probe
+    is one request against GitHub's core budget, which is 60/hr
+    unauthenticated.
+    """
+    cfg = load_config(_make_cfg(tmp_path, sources={"kolla": {"owner": "openstack"}}))
+    responses.add(
+        responses.GET, _commits_url("openstack", "kolla", "stable/2025.2"), status=200
+    )
+    from osism_drift.source import ref_exists
+
+    assert ref_exists("kolla", "stable/2025.2", cfg) is True
+    assert ref_exists("kolla", "stable/2025.2", cfg) is True
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_ref_exists_memoizes_absence_too(tmp_path):
+    """An absent ref is cached as well, not re-probed.
+
+    release_to_ref() walks four candidates per (repo, release) and only the
+    hit is memoized upstream, so caching the misses is what keeps a resolve
+    that falls through to a late candidate from costing its probes twice.
+    """
+    cfg = load_config(_make_cfg(tmp_path, sources={"kolla": {"owner": "openstack"}}))
+    responses.add(
+        responses.GET, _commits_url("openstack", "kolla", "stable/2099.1"), status=404
+    )
+    from osism_drift.source import ref_exists
+
+    assert ref_exists("kolla", "stable/2099.1", cfg) is False
+    assert ref_exists("kolla", "stable/2099.1", cfg) is False
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_ref_exists_cache_is_per_ref(tmp_path):
+    """Distinct refs are distinct questions and are each probed."""
+    cfg = load_config(_make_cfg(tmp_path, sources={"kolla": {"owner": "openstack"}}))
+    responses.add(
+        responses.GET, _commits_url("openstack", "kolla", "stable/2025.1"), status=200
+    )
+    responses.add(
+        responses.GET, _commits_url("openstack", "kolla", "stable/2099.1"), status=404
+    )
+    from osism_drift.source import ref_exists
+
+    assert ref_exists("kolla", "stable/2025.1", cfg) is True
+    assert ref_exists("kolla", "stable/2099.1", cfg) is False
+    assert len(responses.calls) == 2


### PR DESCRIPTION
`release-tox-drift` (periodic-daily) has been aborting with **rc=2** — a source
error, not a drift finding — since the 2026-09-08 drift expansion landed. The
run exhausts GitHub's unauthenticated core API budget (60/hr) and dies before it
reports anything, so the job's red says nothing about the state of the
repositories it was asked to check.

The cause is not request volume. `source.ref_exists()` had no memo, unlike every
neighbouring per-run cache on `Config`, and callers re-ask the same question:

| probe | count |
|-------|-------|
| `ref? ansible_playbooks @ v0.20260721.0` | **70** |
| 16 other `ref?` probes (`kolla`, `kolla_ansible` × release refs) | 1 each |

86 requests per run, 17 distinct. `osism_files()` probes the `playbooks_version`
pin on every call — the guard at `playbooks.py:224-229` that closes the
404-ambiguity hole — and `runtime_interface()` is memoized per *release* while
`osism_interface()`/`osism_files()` are release-independent, so every
per-release miss re-walks them.

### Verification

Full `--group all` run on this branch, **unauthenticated**, the way the job runs
it:

- 17 core-API requests instead of 86, each ref probed exactly once — GitHub's
  own counter reads `used 17 of 60` afterwards
- rc=1, with a report byte-identical to an authenticated run on `main`
- 740 tests pass; flake8 + black clean

Two findings behind the diagnosis, both verified rather than assumed, since they
are what rule the file reads out:

- Archive mode is the default (`driver.py:289`, `archive=not args.use_raw_get`),
  so a run's ~3600 `raw`/`list`/`tree` progress lines are local reads out of one
  extracted tarball per (repo, ref) — not requests.
- `api.github.com/repos/<o>/<r>/tarball/<ref>` is accounted in a **separate
  bucket**: its 302 returns `x-ratelimit-used: 0` and leaves `remaining`
  untouched, while a plain `/repos/<o>/<r>` GET decrements it.

So the ref probes are the only consumers of the 60/hr budget, and no token or
Zuul secret is needed — 17/60 leaves ample headroom as the release range grows.

### The expansion that crossed the limit

- osism/release#2693
- osism/release#2643

Neither is at fault: they multiplied how many callers ask an already-answered
question.

### Side effect worth knowing

The run this unmasks confirms the 2026.1 mirror re-sync is closed — the 230
`kolla_mirror_verbatim` findings are gone:

```
Summary: 5 to act on, 15 advisory, 60 allowlisted, 2 stale entries (80 total)
```

The two stale allowlist entries (`neutron_ovn_vpn_agent_image`/`_tag`, upstream
at master ahead of the supported range) are the pair predicted once the round
landed. They are a separate cleanup, not part of this PR — so expect the job to
go green on source errors and stay red on those two until they are removed.

### Not addressed here

A future budget crossing would again abort rather than degrade the report.
Failing soft on a source error — the `ProbeInconclusive` pattern
`kolla_source_ref_phase` already establishes, lifted to the driver — is left to
its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
